### PR TITLE
Add corpus matcher page

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   },
   "peerDependencies": {
     "typescript": "^5"
+  },
+  "dependencies": {
+    "@tscircuit/schematic-corpus": "^0.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "typescript": "^5"
   },
   "dependencies": {
-    "@tscircuit/schematic-corpus": "^0.0.2"
+    "@tscircuit/schematic-corpus": "^0.0.5"
   }
 }

--- a/pages/corpus-match/corpus-match.page.tsx
+++ b/pages/corpus-match/corpus-match.page.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react"
+import type { BpcGraph, CostConfiguration } from "lib"
+import { getHeuristicNetworkSimilarityDistance } from "lib/heuristic-network-similarity/getHeuristicSimilarityDistance"
+import corpus from "@tscircuit/schematic-corpus/bpc"
+
+const costConfiguration: Partial<CostConfiguration> = {
+  baseOperationCost: 1,
+  colorChangeCostMap: {},
+  costPerUnitDistanceMovingPin: 0.1,
+}
+
+export default function CorpusMatchPage() {
+  const [input, setInput] = useState<string>(
+    '{\n  "boxes": [],\n  "pins": []\n}',
+  )
+  const [results, setResults] = useState<
+    Array<{ name: string; distance: number }>
+  >([])
+
+  const handleMatch = () => {
+    let graph: BpcGraph
+    try {
+      graph = JSON.parse(input)
+    } catch (err) {
+      alert("Invalid JSON")
+      return
+    }
+
+    const corpusGraphs = corpus as Record<string, BpcGraph>
+    const scores = Object.entries(corpusGraphs).map(([name, g]) => ({
+      name,
+      distance: getHeuristicNetworkSimilarityDistance(
+        graph,
+        g,
+        costConfiguration as CostConfiguration,
+      ).distance,
+    }))
+    scores.sort((a, b) => a.distance - b.distance)
+    setResults(scores)
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+      <textarea
+        style={{ width: "600px", height: "200px" }}
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+      />
+      <button onClick={handleMatch}>Match</button>
+      {results.length > 0 && (
+        <table>
+          <thead>
+            <tr>
+              <th>Design</th>
+              <th>Distance</th>
+            </tr>
+          </thead>
+          <tbody>
+            {results.map((r) => (
+              <tr key={r.name}>
+                <td>{r.name}</td>
+                <td>{r.distance.toFixed(2)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}

--- a/pages/corpus-match/corpus-match.page.tsx
+++ b/pages/corpus-match/corpus-match.page.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react"
 import type { BpcGraph, CostConfiguration } from "lib"
 import { getHeuristicNetworkSimilarityDistance } from "lib/heuristic-network-similarity/getHeuristicSimilarityDistance"
-import corpus from "@tscircuit/schematic-corpus/bpc"
+import corpus from "@tscircuit/schematic-corpus/dist/bundled-bpc-graphs.json"
 
 const costConfiguration: Partial<CostConfiguration> = {
   baseOperationCost: 1,


### PR DESCRIPTION
## Summary
- add @tscircuit/schematic-corpus dependency
- add a simple page for comparing a BPC graph against the corpus

## Testing
- `bun test ./tests/graph-network-transformer/GraphNetworkTransformer.test.ts`
- `bun test ./tests/graph-network-transformer/GraphNetworkTransformerDebuggerPage.test.ts`
- `bun test ./tests/getGraphicsForBpcGraph/getGraphicsForBpcGraph01.test.ts`
- `bun test ./tests/heuristic-network-similarity/calculateMappingCost/calculateMappingCost01.test.ts`
- `bun test ./tests/svg.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68586738b194832e8dbdd9e216f7ca89