### PR TITLE
Implement box side graph utilities

### DIFF
--- a/lib/graph-utils/box-sides/findIsolatedBoxSides.ts
+++ b/lib/graph-utils/box-sides/findIsolatedBoxSides.ts
@@ -1,0 +1,109 @@
+import type { BpcGraph } from "lib/types"
+import { getPinDirection } from "lib/graph-utils/getPinDirection"
+import { getBoxSideSubgraph, type Side } from "./getBoxSideSubgraph"
+import { mergeBoxSideSubgraphs } from "./mergeBoxSideSubgraphs"
+
+export const findIsolatedBoxSides = (g: BpcGraph, boxId: string): Side[][] => {
+  const pins = g.pins.filter((p) => p.boxId === boxId)
+  const sides = new Set<Side>()
+  for (const p of pins) {
+    const dir = getPinDirection(g, p.pinId)
+    const side: Side =
+      dir === "x-"
+        ? "left"
+        : dir === "x+"
+          ? "right"
+          : dir === "y+"
+            ? "top"
+            : "bottom"
+    sides.add(side)
+  }
+
+  const sideList = Array.from(sides)
+  if (sideList.length === 0) return []
+
+  const subgraphs = sideList.map((side) =>
+    getBoxSideSubgraph({ bpcGraph: g, boxId, side }),
+  )
+  const merged = mergeBoxSideSubgraphs(subgraphs, boxId)
+
+  // Build adjacency between pins based on networks
+  const adjacency = new Map<string, Set<string>>() // pinId -> connected pinIds
+  for (const p of merged.pins) adjacency.set(p.pinId, new Set())
+  const pinsByNet: Record<string, string[]> = {}
+  for (const p of merged.pins) {
+    pinsByNet[p.networkId] ??= []
+    pinsByNet[p.networkId]!.push(p.pinId)
+  }
+  for (const list of Object.values(pinsByNet)) {
+    for (let i = 0; i < list.length; i++) {
+      for (let j = i + 1; j < list.length; j++) {
+        adjacency.get(list[i]!)!.add(list[j]!)
+        adjacency.get(list[j]!)!.add(list[i]!)
+      }
+    }
+  }
+
+  // Compute connected components of pins
+  const compByPin = new Map<string, number>()
+  let compIdx = 0
+  for (const pinId of adjacency.keys()) {
+    if (compByPin.has(pinId)) continue
+    const stack = [pinId]
+    while (stack.length) {
+      const pid = stack.pop()!
+      if (compByPin.has(pid)) continue
+      compByPin.set(pid, compIdx)
+      for (const nb of adjacency.get(pid) ?? []) stack.push(nb)
+    }
+    compIdx++
+  }
+
+  // Map components to sides
+  const compsBySide = new Map<Side, Set<number>>()
+  for (const side of sideList) compsBySide.set(side, new Set())
+  for (const p of merged.pins) {
+    const comp = compByPin.get(p.pinId)!
+    const sMatch = sideList.find((s) => `${boxId}-${s}` === p.boxId)
+    if (sMatch) compsBySide.get(sMatch)!.add(comp)
+  }
+
+  // Build side adjacency based on shared components
+  const sideAdj = new Map<Side, Set<Side>>()
+  for (const s of sideList) sideAdj.set(s, new Set())
+  for (const [sideA, compsA] of compsBySide) {
+    for (const [sideB, compsB] of compsBySide) {
+      if (sideA === sideB) continue
+      for (const c of compsA) {
+        if (compsB.has(c)) {
+          sideAdj.get(sideA)!.add(sideB)
+          sideAdj.get(sideB)!.add(sideA)
+          break
+        }
+      }
+    }
+  }
+
+  // Connected components on sides
+  const visitedSides = new Set<Side>()
+  const result: Side[][] = []
+  for (const side of sideList) {
+    if (visitedSides.has(side)) continue
+    const stack = [side]
+    visitedSides.add(side)
+    const group: Side[] = []
+    while (stack.length) {
+      const s = stack.pop()!
+      group.push(s)
+      for (const nb of sideAdj.get(s) ?? []) {
+        if (!visitedSides.has(nb)) {
+          visitedSides.add(nb)
+          stack.push(nb)
+        }
+      }
+    }
+    if (group.length) result.push(group)
+  }
+
+  return result
+}

--- a/lib/graph-utils/box-sides/getBoxSideSubgraph.ts
+++ b/lib/graph-utils/box-sides/getBoxSideSubgraph.ts
@@ -1,0 +1,52 @@
+import type { BpcGraph, Direction } from "lib/types"
+import { getPinDirection } from "lib/graph-utils/getPinDirection"
+
+export type Side = "left" | "right" | "top" | "bottom"
+
+const sideToDirection: Record<Side, Direction> = {
+  left: "x-",
+  right: "x+",
+  top: "y+",
+  bottom: "y-",
+}
+
+export const getBoxSideSubgraph = ({
+  bpcGraph,
+  boxId,
+  side,
+}: {
+  bpcGraph: BpcGraph
+  boxId: string
+  side: Side
+}): BpcGraph => {
+  const dir = sideToDirection[side]
+  const sideBoxId = `${boxId}-${side}`
+
+  const result: BpcGraph = { boxes: [], pins: [] }
+
+  const box = bpcGraph.boxes.find((b) => b.boxId === boxId)
+  if (!box) throw new Error(`Box \"${boxId}\" not found`)
+
+  // Add all other boxes
+  for (const b of bpcGraph.boxes) {
+    if (b.boxId === boxId) continue
+    result.boxes.push(structuredClone(b))
+  }
+
+  // Add side-specific box
+  result.boxes.push({ ...structuredClone(box), boxId: sideBoxId })
+
+  // Add pins
+  for (const p of bpcGraph.pins) {
+    if (p.boxId === boxId) {
+      const pDir = getPinDirection(bpcGraph, p.pinId)
+      if (pDir === dir) {
+        result.pins.push({ ...structuredClone(p), boxId: sideBoxId })
+      }
+    } else {
+      result.pins.push(structuredClone(p))
+    }
+  }
+
+  return result
+}

--- a/lib/graph-utils/box-sides/getBoxSideSubgraph.ts
+++ b/lib/graph-utils/box-sides/getBoxSideSubgraph.ts
@@ -1,4 +1,4 @@
-import type { BpcGraph, Direction } from "lib/types"
+import type { BpcGraph, MixedBpcGraph, Direction } from "lib/types"
 import { getPinDirection } from "lib/graph-utils/getPinDirection"
 
 export type Side = "left" | "right" | "top" | "bottom"
@@ -18,11 +18,11 @@ export const getBoxSideSubgraph = ({
   bpcGraph: BpcGraph
   boxId: string
   side: Side
-}): BpcGraph => {
+}): MixedBpcGraph => {
   const dir = sideToDirection[side]
   const sideBoxId = `${boxId}-${side}`
 
-  const result: BpcGraph = { boxes: [], pins: [] }
+  const result: MixedBpcGraph = { boxes: [], pins: [] }
 
   const box = bpcGraph.boxes.find((b) => b.boxId === boxId)
   if (!box) throw new Error(`Box \"${boxId}\" not found`)

--- a/lib/graph-utils/box-sides/mergeBoxSideSubgraphs.ts
+++ b/lib/graph-utils/box-sides/mergeBoxSideSubgraphs.ts
@@ -1,0 +1,24 @@
+import type { BpcGraph } from "lib/types"
+
+export const mergeBoxSideSubgraphs = (
+  graphs: BpcGraph[],
+  _boxId: string,
+): BpcGraph => {
+  const merged: BpcGraph = { boxes: [], pins: [] }
+  const boxMap = new Map<string, BpcGraph["boxes"][0]>()
+  const pinMap = new Map<string, BpcGraph["pins"][0]>()
+
+  for (const g of graphs) {
+    for (const box of g.boxes) {
+      if (!boxMap.has(box.boxId)) boxMap.set(box.boxId, structuredClone(box))
+    }
+    for (const pin of g.pins) {
+      if (!pinMap.has(pin.pinId)) pinMap.set(pin.pinId, structuredClone(pin))
+    }
+  }
+
+  merged.boxes = Array.from(boxMap.values())
+  merged.pins = Array.from(pinMap.values())
+
+  return merged
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,3 +11,6 @@ export * from "./adjacency-matrix-network-similarity/getAdjacencyMatrixFromFlatB
 export * from "./adjacency-matrix-network-similarity/getApproximateAssignments"
 export * from "./adjacency-matrix-network-similarity/wlDotProduct"
 export * from "./adjacency-matrix-network-similarity/wlFeatureVec"
+export * from "./graph-utils/box-sides/getBoxSideSubgraph"
+export * from "./graph-utils/box-sides/mergeBoxSideSubgraphs"
+export * from "./graph-utils/box-sides/findIsolatedBoxSides"

--- a/tests/box-sides/findIsolatedBoxSides.test.ts
+++ b/tests/box-sides/findIsolatedBoxSides.test.ts
@@ -1,0 +1,94 @@
+import { expect, test } from "bun:test"
+import { findIsolatedBoxSides } from "lib/graph-utils/box-sides/findIsolatedBoxSides"
+import type { BpcGraph } from "lib/types"
+
+test("findIsolatedBoxSides isolates disconnected sides", () => {
+  const g: BpcGraph = {
+    boxes: [
+      { kind: "fixed", boxId: "A", center: { x: 0, y: 0 } },
+      { kind: "fixed", boxId: "B", center: { x: 10, y: 0 } },
+    ],
+    pins: [
+      {
+        boxId: "A",
+        pinId: "AL",
+        networkId: "N1",
+        color: "red",
+        offset: { x: -1, y: 0 },
+      },
+      {
+        boxId: "B",
+        pinId: "BR",
+        networkId: "N1",
+        color: "red",
+        offset: { x: 1, y: 0 },
+      },
+      {
+        boxId: "A",
+        pinId: "AR",
+        networkId: "N2",
+        color: "blue",
+        offset: { x: 1, y: 0 },
+      },
+      {
+        boxId: "B",
+        pinId: "BL",
+        networkId: "N2",
+        color: "blue",
+        offset: { x: -1, y: 0 },
+      },
+    ],
+  }
+
+  const result = findIsolatedBoxSides(g, "A")
+  expect(result).toEqual([["left"], ["right"]])
+})
+
+test("findIsolatedBoxSides groups connected sides", () => {
+  const g: BpcGraph = {
+    boxes: [
+      { kind: "fixed", boxId: "A", center: { x: 0, y: 0 } },
+      { kind: "fixed", boxId: "B", center: { x: 5, y: 0 } },
+    ],
+    pins: [
+      {
+        boxId: "A",
+        pinId: "AL",
+        networkId: "N1",
+        color: "red",
+        offset: { x: -1, y: 0 },
+      },
+      {
+        boxId: "B",
+        pinId: "BR1",
+        networkId: "N1",
+        color: "red",
+        offset: { x: 1, y: 0 },
+      },
+      {
+        boxId: "B",
+        pinId: "BL1",
+        networkId: "N1",
+        color: "red",
+        offset: { x: -1, y: 0 },
+      },
+      {
+        boxId: "A",
+        pinId: "AT",
+        networkId: "N1",
+        color: "red",
+        offset: { x: 0, y: 1 },
+      },
+      {
+        boxId: "A",
+        pinId: "AR",
+        networkId: "N2",
+        color: "blue",
+        offset: { x: 1, y: 0 },
+      },
+    ],
+  }
+
+  const result = findIsolatedBoxSides(g, "A")
+  expect(result).toEqual([["left", "top"], ["right"]])
+})


### PR DESCRIPTION
## Summary
- add helper to build subgraph for a single side of a box
- merge multiple box side subgraphs
- detect connected groups of box sides
- test finding isolated box sides

## Testing
- `bun test tests/box-sides/findIsolatedBoxSides.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_686150d2d7a8832e8eb4f1b0f8e4fa09