### PR TITLE
Add API README and example tests

### DIFF
--- a/tests/readme/__snapshots__/getGraphicsExample.snap.svg
+++ b/tests/readme/__snapshots__/getGraphicsExample.snap.svg
@@ -1,0 +1,83 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+  <g>
+    <circle data-type="point" data-label="P1
+red
+N1" data-x="0.5" data-y="0" cx="65.45454545454547" cy="320" r="3" fill="red" /><text x="70.45454545454547" y="315" font-family="sans-serif" font-size="12">P1
+      red
+      N1</text>
+  </g>
+  <g>
+    <circle data-type="point" data-label="P1
+red
+N1" data-x="1.5" data-y="0" cx="574.5454545454545" cy="320" r="3" fill="red" /><text x="579.5454545454545" y="315" font-family="sans-serif" font-size="12">P1
+      red
+      N1</text>
+  </g>
+  <g>
+    <polyline data-points="0.5,0 0.5,0" data-type="line" data-label="" points="65.45454545454547,320 65.45454545454547,320" fill="none" stroke="hsl(0, 100%, 50%, 0.2)" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="A" data-x="0.5" data-y="0" x="40.00000000000003" y="294.54545454545456" width="50.90909090909091" height="50.90909090909088" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.0019642857142857144" /><text x="45.00000000000003" y="294.54545454545456" font-family="sans-serif" dominant-baseline="text-before-edge" font-size="3.0545454545454533" fill="black">A</text>
+  </g>
+  <g>
+    <rect data-type="rect" data-label="B" data-x="1.5" data-y="0" x="549.090909090909" y="294.54545454545456" width="50.90909090909099" height="50.90909090909088" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.0019642857142857144" /><text x="554.090909090909" y="294.54545454545456" font-family="sans-serif" dominant-baseline="text-before-edge" font-size="3.054545454545456" fill="black">B</text>
+  </g>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 509.09090909090907,
+        "c": 0,
+        "e": -189.09090909090907,
+        "b": 0,
+        "d": -509.09090909090907,
+        "f": 320
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/readme/__snapshots__/renetworkExample.snap.svg
+++ b/tests/readme/__snapshots__/renetworkExample.snap.svg
@@ -1,0 +1,170 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+  <g>
+    <circle data-type="point" data-label="p
+red
+net" data-x="-0.5" data-y="0" cx="51.313131313131336" cy="320" r="3" fill="red" /><text x="56.313131313131336" y="315" font-family="sans-serif" font-size="12">p
+      red
+      net</text>
+  </g>
+  <g>
+    <circle data-type="point" data-label="p1
+red
+net" data-x="-0.5" data-y="0" cx="51.313131313131336" cy="320" r="3" fill="red" /><text x="56.313131313131336" y="315" font-family="sans-serif" font-size="12">p1
+      red
+      net</text>
+  </g>
+  <g>
+    <circle data-type="point" data-label="p2
+red
+net" data-x="0.5" data-y="0" cx="277.57575757575756" cy="320" r="3" fill="red" /><text x="282.57575757575756" y="315" font-family="sans-serif" font-size="12">p2
+      red
+      net</text>
+  </g>
+  <g>
+    <circle data-type="point" data-label="p
+red
+net" data-x="0.5" data-y="0" cx="277.57575757575756" cy="320" r="3" fill="red" /><text x="282.57575757575756" y="315" font-family="sans-serif" font-size="12">p
+      red
+      net</text>
+  </g>
+  <g>
+    <circle data-type="point" data-label="p
+red
+net" data-x="0.875" data-y="0" cx="362.4242424242424" cy="320" r="3" fill="red" /><text x="367.4242424242424" y="315" font-family="sans-serif" font-size="12">p
+      red
+      net</text>
+  </g>
+  <g>
+    <circle data-type="point" data-label="p1
+red
+net" data-x="0.875" data-y="0" cx="362.4242424242424" cy="320" r="3" fill="red" /><text x="367.4242424242424" y="315" font-family="sans-serif" font-size="12">p1
+      red
+      net</text>
+  </g>
+  <g>
+    <circle data-type="point" data-label="p2
+red
+net" data-x="1.875" data-y="0" cx="588.6868686868686" cy="320" r="3" fill="red" /><text x="593.6868686868686" y="315" font-family="sans-serif" font-size="12">p2
+      red
+      net</text>
+  </g>
+  <g>
+    <circle data-type="point" data-label="p
+red
+net" data-x="1.875" data-y="0" cx="588.6868686868686" cy="320" r="3" fill="red" /><text x="593.6868686868686" y="315" font-family="sans-serif" font-size="12">p
+      red
+      net</text>
+  </g>
+  <g>
+    <polyline data-points="-0.5,0 -0.5,0" data-type="line" data-label="" points="51.313131313131336,320 51.313131313131336,320" fill="none" stroke="hsl(0, 100%, 50%, 0.2)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-0.5,0 -0.5,0" data-type="line" data-label="" points="51.313131313131336,320 51.313131313131336,320" fill="none" stroke="hsl(0, 100%, 50%, 0.2)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-0.5,0 0.5,0" data-type="line" data-label="" points="51.313131313131336,320 277.57575757575756,320" fill="none" stroke="hsl(0, 100%, 50%, 0.2)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-0.5,0 -0.5,0" data-type="line" data-label="" points="51.313131313131336,320 51.313131313131336,320" fill="none" stroke="hsl(0, 100%, 50%, 0.2)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="-0.5,0 0.5,0" data-type="line" data-label="" points="51.313131313131336,320 277.57575757575756,320" fill="none" stroke="hsl(0, 100%, 50%, 0.2)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="0.5,0 -0.5,0" data-type="line" data-label="" points="277.57575757575756,320 51.313131313131336,320" fill="none" stroke="hsl(0, 100%, 50%, 0.2)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="0.875,0 0.875,0" data-type="line" data-label="" points="362.4242424242424,320 362.4242424242424,320" fill="none" stroke="hsl(0, 100%, 50%, 0.2)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="0.875,0 0.875,0" data-type="line" data-label="" points="362.4242424242424,320 362.4242424242424,320" fill="none" stroke="hsl(0, 100%, 50%, 0.2)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="0.875,0 1.875,0" data-type="line" data-label="" points="362.4242424242424,320 588.6868686868686,320" fill="none" stroke="hsl(0, 100%, 50%, 0.2)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="0.875,0 0.875,0" data-type="line" data-label="" points="362.4242424242424,320 362.4242424242424,320" fill="none" stroke="hsl(0, 100%, 50%, 0.2)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="0.875,0 1.875,0" data-type="line" data-label="" points="362.4242424242424,320 588.6868686868686,320" fill="none" stroke="hsl(0, 100%, 50%, 0.2)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="1.875,0 0.875,0" data-type="line" data-label="" points="588.6868686868686,320 362.4242424242424,320" fill="none" stroke="hsl(0, 100%, 50%, 0.2)" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="L" data-x="-0.5" data-y="0" x="40.000000000000014" y="308.6868686868687" width="22.62626262626263" height="22.626262626262587" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.004419642857142857" /><text x="45.000000000000014" y="308.6868686868687" font-family="sans-serif" dominant-baseline="text-before-edge" font-size="1.3575757575757565" fill="black">L</text>
+  </g>
+  <g>
+    <rect data-type="rect" data-label="M" data-x="0" data-y="0" x="40.000000000000014" y="308.6868686868687" width="248.8888888888889" height="22.626262626262587" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.004419642857142857" /><text x="45.000000000000014" y="308.6868686868687" font-family="sans-serif" dominant-baseline="text-before-edge" font-size="8.145454545454545" fill="black">M</text>
+  </g>
+  <g>
+    <rect data-type="rect" data-label="R" data-x="0.5" data-y="0" x="266.26262626262627" y="308.6868686868687" width="22.626262626262644" height="22.626262626262587" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.004419642857142857" /><text x="271.26262626262627" y="308.6868686868687" font-family="sans-serif" dominant-baseline="text-before-edge" font-size="1.357575757575757" fill="black">R</text>
+  </g>
+  <g>
+    <rect data-type="rect" data-label="L" data-x="0.875" data-y="0" x="351.1111111111111" y="308.6868686868687" width="22.626262626262644" height="22.626262626262587" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.004419642857142857" /><text x="356.1111111111111" y="308.6868686868687" font-family="sans-serif" dominant-baseline="text-before-edge" font-size="1.357575757575757" fill="black">L</text>
+  </g>
+  <g>
+    <rect data-type="rect" data-label="M" data-x="1.375" data-y="0" x="351.1111111111111" y="308.6868686868687" width="248.8888888888889" height="22.626262626262587" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.004419642857142857" /><text x="356.1111111111111" y="308.6868686868687" font-family="sans-serif" dominant-baseline="text-before-edge" font-size="8.145454545454545" fill="black">M</text>
+  </g>
+  <g>
+    <rect data-type="rect" data-label="R" data-x="1.875" data-y="0" x="577.3737373737374" y="308.6868686868687" width="22.626262626262587" height="22.626262626262587" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.004419642857142857" /><text x="582.3737373737374" y="308.6868686868687" font-family="sans-serif" dominant-baseline="text-before-edge" font-size="1.3575757575757552" fill="black">R</text>
+  </g><text data-type="text" data-label="Original" data-x="-0.55" data-y="0.05" x="40.000000000000014" y="308.6868686868687" fill="black" font-size="1.1313131313131315" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Original</text><text data-type="text" data-label="Renetworked" data-x="0.825" data-y="0.05" x="351.1111111111111" y="308.6868686868687" fill="black" font-size="1.1313131313131315" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Renetworked</text>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 226.26262626262624,
+        "c": 0,
+        "e": 164.44444444444446,
+        "b": 0,
+        "d": -226.26262626262624,
+        "f": 320
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/readme/getGraphicsExample.test.ts
+++ b/tests/readme/getGraphicsExample.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test"
+import { getGraphicsForBpcGraph } from "lib/debug/getGraphicsForBpcGraph"
+import { getSvgFromGraphicsObject } from "graphics-debug"
+import type { BpcGraph } from "lib/types"
+
+const g: BpcGraph = {
+  boxes: [
+    { boxId: "A", kind: "fixed", center: { x: 0, y: 0 } },
+    { boxId: "B", kind: "fixed", center: { x: 2, y: 0 } },
+  ],
+  pins: [
+    {
+      boxId: "A",
+      pinId: "P1",
+      offset: { x: 0.5, y: 0 },
+      color: "red",
+      networkId: "N1",
+    },
+    {
+      boxId: "B",
+      pinId: "P1",
+      offset: { x: -0.5, y: 0 },
+      color: "red",
+      networkId: "N1",
+    },
+  ],
+}
+
+test("getGraphicsExample", () => {
+  const svg = getSvgFromGraphicsObject(getGraphicsForBpcGraph(g), {
+    backgroundColor: "white",
+  })
+  expect(svg).toMatchSvgSnapshot(import.meta.path)
+})

--- a/tests/readme/renetworkExample.test.ts
+++ b/tests/readme/renetworkExample.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "bun:test"
+import { renetworkWithCondition } from "lib/renetwork/renetworkWithCondition"
+import { getGraphicsForBpcGraph } from "lib/debug/getGraphicsForBpcGraph"
+import {
+  stackGraphicsHorizontally,
+  getSvgFromGraphicsObject,
+} from "graphics-debug"
+import type { BpcGraph } from "lib/types"
+
+test("renetworkExample", () => {
+  const g: BpcGraph = {
+    boxes: [
+      { boxId: "L", kind: "fixed", center: { x: -1, y: 0 } },
+      { boxId: "M", kind: "fixed", center: { x: 0, y: 0 } },
+      { boxId: "R", kind: "fixed", center: { x: 1, y: 0 } },
+    ],
+    pins: [
+      {
+        boxId: "L",
+        pinId: "p",
+        offset: { x: 0.5, y: 0 },
+        color: "red",
+        networkId: "net",
+      },
+      {
+        boxId: "M",
+        pinId: "p1",
+        offset: { x: -0.5, y: 0 },
+        color: "red",
+        networkId: "net",
+      },
+      {
+        boxId: "M",
+        pinId: "p2",
+        offset: { x: 0.5, y: 0 },
+        color: "red",
+        networkId: "net",
+      },
+      {
+        boxId: "R",
+        pinId: "p",
+        offset: { x: -0.5, y: 0 },
+        color: "red",
+        networkId: "net",
+      },
+    ],
+  }
+
+  const { renetworkedGraph } = renetworkWithCondition(g, (from, to) => {
+    const side = (p: {
+      box: { center?: { x: number } }
+      pin: { offset: { x: number } }
+    }) => ((p.box.center?.x ?? 0) + p.pin.offset.x < 0 ? "left" : "right")
+    return side(from) === side(to)
+  })
+
+  const svg = getSvgFromGraphicsObject(
+    stackGraphicsHorizontally([
+      getGraphicsForBpcGraph(g, { title: "Original" }),
+      getGraphicsForBpcGraph(renetworkedGraph, { title: "Renetworked" }),
+    ]),
+    { backgroundColor: "white" },
+  )
+
+  expect(svg).toMatchSvgSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## Summary
- document library API and basic usage in README
- add snapshot based examples under `tests/readme`

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/readme`

------
https://chatgpt.com/codex/tasks/task_b_6861bd23f7f0832ea7aa3cdbef214695