### PR TITLE
Improve README with graphical examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,23 @@ schematic like connection graph is produced.
 
 This repository provides utilities for manipulating and comparing BPC graphs.
 
+## Contents
+
+- [Where BPC graphs are used](#where-bpc-graphs-are-used)
+- [Installation](#installation)
+- [Quick Example](#quick-example)
+- [API](#api)
+  - [getGraphBounds](#getgraphboundsgraph)
+  - [getPinPosition](#getpinpositiongraph-pinid)
+  - [getPinDirection](#getpindirectiongraph-pinid)
+  - [assignFloatingBoxPositions](#assignfloatingboxpositionsgraph)
+  - [netAdaptBpcGraph](#netadaptbpcgraphsource-target)
+  - [renetworkWithCondition](#renetworkwithconditiongraph-predicate)
+  - [convertToFlatBpcGraph](#convertoflatbpcgraphmixed)
+  - [convertFromFlatBpcGraph](#convertfromflatbpcgraphflat)
+  - [getBpcGraphWlDistance](#getbpcgraphwldistancea-b)
+  - [ForceDirectedLayoutSolver](#forcedirectedlayoutsolver)
+
 ## Where BPC graphs are used
 
 When automatically laying out schematics the tools in this repo convert an initial
@@ -54,29 +71,45 @@ The snapshot generated in `tests/readme/getGraphicsExample.test.ts` renders as:
 
 ## API
 
-### Graph Utilities
+### getGraphBounds(graph)
 
-- **getGraphBounds(graph)** → `{ minX, minY, maxX, maxY }`
-- **getPinPosition(graph, pinId)** → absolute coordinates of a pin
-- **getPinDirection(graph, pinId)** → `"x-" | "x+" | "y-" | "y+" | null`
+![Graph utils example](tests/readme/__snapshots__/graphUtilsExample.snap.svg)
 
-### Graph Editing
+### getPinPosition(graph, pinId)
 
-- **assignFloatingBoxPositions(graph)** – infers positions for floating boxes
-- **netAdaptBpcGraph(source, target)** – adapt a fixed graph to match the networks of a target graph
-- **renetworkWithCondition(graph, predicate)** – split networks based on a predicate. The example in `tests/readme/renetworkExample.test.ts` produces:
+_See graph utils example above_
+
+### getPinDirection(graph, pinId)
+
+_See graph utils example above_
+
+### assignFloatingBoxPositions(graph)
+
+![Assign floating](tests/bpc-graph-editing/__snapshots__/assignFloatingBoxPositions.snap.svg)
+
+### netAdaptBpcGraph(source, target)
+
+![Net adapt](tests/bpc-graph-editing/__snapshots__/netAdaptBpcGraph03.snap.svg)
+
+### renetworkWithCondition(graph, predicate)
 
 ![Renetwork result](tests/readme/__snapshots__/renetworkExample.snap.svg)
 
-### Conversion Utilities
+### convertToFlatBpcGraph(mixed)
 
-- **convertToFlatBpcGraph(mixed)** – flatten a BPC graph into nodes and undirected edges
-- **convertFromFlatBpcGraph(flat)** – rebuild a mixed graph from the flat representation
+![Convert flat](tests/readme/__snapshots__/convertFlatExample.snap.svg)
 
-### Similarity & Layout
+### convertFromFlatBpcGraph(flat)
 
-- **getBpcGraphWlDistance(a, b)** – compute Weisfeiler-Leman distance between graphs
-- **ForceDirectedLayoutSolver** – physics based solver for positioning boxes
+_Result identical to original, see convert flat example above_
+
+### getBpcGraphWlDistance(a, b)
+
+![WL distance](tests/adjacency-matrix-network-similarity/__snapshots__/eigen01.snap.svg)
+
+### ForceDirectedLayoutSolver
+
+![Force solver](tests/schematic-partition-layout-with-corpus/__snapshots__/partition01.snap.svg)
 
 All type definitions can be imported from `bpc-graph` as well and are located in
 `lib/types.ts`.

--- a/tests/readme/__snapshots__/convertFlatExample.snap.svg
+++ b/tests/readme/__snapshots__/convertFlatExample.snap.svg
@@ -1,0 +1,106 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+  <g>
+    <circle data-type="point" data-label="P1
+red
+N1" data-x="1" data-y="0" cx="277.5757575757576" cy="320" r="3" fill="red" /><text x="282.5757575757576" y="315" font-family="sans-serif" font-size="12">P1
+      red
+      N1</text>
+  </g>
+  <g>
+    <circle data-type="point" data-label="P2
+blue
+N1" data-x="0" data-y="0" cx="51.313131313131294" cy="320" r="3" fill="blue" /><text x="56.313131313131294" y="315" font-family="sans-serif" font-size="12">P2
+      blue
+      N1</text>
+  </g>
+  <g>
+    <circle data-type="point" data-label="P1
+red
+net0" data-x="2.375" data-y="0" cx="588.6868686868687" cy="320" r="3" fill="red" /><text x="593.6868686868687" y="315" font-family="sans-serif" font-size="12">P1
+      red
+      net0</text>
+  </g>
+  <g>
+    <circle data-type="point" data-label="P2
+blue
+net0" data-x="1.3750000000000002" data-y="0" cx="362.4242424242425" cy="320" r="3" fill="blue" /><text x="367.4242424242425" y="315" font-family="sans-serif" font-size="12">P2
+      blue
+      net0</text>
+  </g>
+  <g>
+    <polyline data-points="1,0 0,0" data-type="line" data-label="" points="277.5757575757576,320 51.313131313131294,320" fill="none" stroke="hsl(0, 100%, 50%, 0.2)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="2.375,0 1.3750000000000002,0" data-type="line" data-label="" points="588.6868686868687,320 362.4242424242425,320" fill="none" stroke="hsl(0, 100%, 50%, 0.2)" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="B1" data-x="1" data-y="0" x="266.26262626262627" y="308.6868686868687" width="22.626262626262644" height="22.626262626262587" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.004419642857142856" /><text x="271.26262626262627" y="308.6868686868687" font-family="sans-serif" dominant-baseline="text-before-edge" font-size="1.357575757575757" fill="black">B1</text>
+  </g>
+  <g>
+    <rect data-type="rect" data-label="B2" data-x="0" data-y="0" x="39.99999999999998" y="308.6868686868687" width="22.62626262626263" height="22.626262626262587" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.004419642857142856" /><text x="44.99999999999998" y="308.6868686868687" font-family="sans-serif" dominant-baseline="text-before-edge" font-size="1.3575757575757565" fill="black">B2</text>
+  </g>
+  <g>
+    <rect data-type="rect" data-label="B1" data-x="2.375" data-y="0" x="577.3737373737375" y="308.6868686868687" width="22.626262626262474" height="22.626262626262587" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.004419642857142856" /><text x="582.3737373737375" y="308.6868686868687" font-family="sans-serif" dominant-baseline="text-before-edge" font-size="1.3575757575757517" fill="black">B1</text>
+  </g>
+  <g>
+    <rect data-type="rect" data-label="B2" data-x="1.3750000000000002" data-y="0" x="351.1111111111112" y="308.6868686868687" width="22.626262626262644" height="22.626262626262587" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.004419642857142856" /><text x="356.1111111111112" y="308.6868686868687" font-family="sans-serif" dominant-baseline="text-before-edge" font-size="1.357575757575757" fill="black">B2</text>
+  </g><text data-type="text" data-label="Original" data-x="-0.05" data-y="0.05" x="39.99999999999998" y="308.6868686868687" fill="black" font-size="1.1313131313131317" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Original</text><text data-type="text" data-label="Round Trip" data-x="1.3250000000000002" data-y="0.05" x="351.1111111111112" y="308.6868686868687" fill="black" font-size="1.1313131313131317" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Round Trip</text>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 226.2626262626263,
+        "c": 0,
+        "e": 51.313131313131294,
+        "b": 0,
+        "d": -226.2626262626263,
+        "f": 320
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/readme/__snapshots__/graphUtilsExample.snap.svg
+++ b/tests/readme/__snapshots__/graphUtilsExample.snap.svg
@@ -1,0 +1,111 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+  <g>
+    <circle data-type="point" data-label="P1
+red
+N1" data-x="0.5" data-y="0" cx="51.313131313131336" cy="320" r="3" fill="red" /><text x="56.313131313131336" y="315" font-family="sans-serif" font-size="12">P1
+      red
+      N1</text>
+  </g>
+  <g>
+    <circle data-type="point" data-label="P1
+red
+N1" data-x="1.5" data-y="0" cx="277.5757575757576" cy="320" r="3" fill="red" /><text x="282.5757575757576" y="315" font-family="sans-serif" font-size="12">P1
+      red
+      N1</text>
+  </g>
+  <g>
+    <circle data-type="point" data-label="P1
+red
+N1" data-x="1.8750000000000002" data-y="0" cx="362.42424242424255" cy="320" r="3" fill="red" /><text x="367.42424242424255" y="315" font-family="sans-serif" font-size="12">P1
+      red
+      N1</text>
+  </g>
+  <g>
+    <circle data-type="point" data-label="P1
+red
+N1" data-x="2.875" data-y="0" cx="588.6868686868688" cy="320" r="3" fill="red" /><text x="593.6868686868688" y="315" font-family="sans-serif" font-size="12">P1
+      red
+      N1</text>
+  </g>
+  <g>
+    <polyline data-points="0.5,0 0.5,0" data-type="line" data-label="" points="51.313131313131336,320 51.313131313131336,320" fill="none" stroke="hsl(0, 100%, 50%, 0.2)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="1.8750000000000002,0 1.8750000000000002,0" data-type="line" data-label="" points="362.42424242424255,320 362.42424242424255,320" fill="none" stroke="hsl(0, 100%, 50%, 0.2)" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="A" data-x="0.5" data-y="0" x="40.00000000000003" y="308.6868686868687" width="22.62626262626263" height="22.626262626262587" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.004419642857142856" /><text x="45.00000000000003" y="308.6868686868687" font-family="sans-serif" dominant-baseline="text-before-edge" font-size="1.3575757575757565" fill="black">A</text>
+  </g>
+  <g>
+    <rect data-type="rect" data-label="B" data-x="1.5" data-y="0" x="266.2626262626263" y="308.6868686868687" width="22.626262626262644" height="22.626262626262587" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.004419642857142856" /><text x="271.2626262626263" y="308.6868686868687" font-family="sans-serif" dominant-baseline="text-before-edge" font-size="1.357575757575757" fill="black">B</text>
+  </g>
+  <g>
+    <rect data-type="rect" data-label="A" data-x="1.8750000000000002" data-y="0" x="351.1111111111112" y="308.6868686868687" width="22.626262626262644" height="22.626262626262587" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.004419642857142856" /><text x="356.1111111111112" y="308.6868686868687" font-family="sans-serif" dominant-baseline="text-before-edge" font-size="1.357575757575757" fill="black">A</text>
+  </g>
+  <g>
+    <rect data-type="rect" data-label="B" data-x="2.875" data-y="0" x="577.3737373737374" y="308.6868686868687" width="22.626262626262587" height="22.626262626262587" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.004419642857142856" /><text x="582.3737373737374" y="308.6868686868687" font-family="sans-serif" dominant-baseline="text-before-edge" font-size="1.3575757575757552" fill="black">B</text>
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="2.375" data-y="0" x="362.4242424242425" y="320" width="226.26262626262633" height="0" fill="transparent" stroke="black" stroke-width="0.004419642857142856" />
+  </g><text data-type="text" data-label="Original" data-x="0.45" data-y="0.05" x="40.00000000000003" y="308.6868686868687" fill="black" font-size="1.1313131313131317" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Original</text><text data-type="text" data-label="With Info" data-x="1.8250000000000002" data-y="0.05" x="351.1111111111112" y="308.6868686868687" fill="black" font-size="1.1313131313131317" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">With Info</text><text data-type="text" data-label="bounds: [0.5, 0] - [1.5, 0]
+P1@0.5,0 dir:x+" data-x="1.8250000000000002" data-y="-0.05" x="351.1111111111112" y="331.3131313131313" fill="black" font-size="1.1313131313131317" font-family="sans-serif" text-anchor="start" dominant-baseline="text-before-edge">bounds: [0.5, 0] - [1.5, 0]
+    P1@0.5,0 dir:x+</text>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 226.2626262626263,
+        "c": 0,
+        "e": -61.81818181818181,
+        "b": 0,
+        "d": -226.2626262626263,
+        "f": 320
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/readme/convertFlatExample.test.ts
+++ b/tests/readme/convertFlatExample.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+import { convertToFlatBpcGraph } from "lib/flat-bpc/convertToFlatBpcGraph"
+import { convertFromFlatBpcGraph } from "lib/flat-bpc/convertFromFlatBpcGraph"
+import { getGraphicsForBpcGraph } from "lib/debug/getGraphicsForBpcGraph"
+import {
+  stackGraphicsHorizontally,
+  getSvgFromGraphicsObject,
+} from "graphics-debug"
+import type { MixedBpcGraph } from "lib/types"
+
+const g: MixedBpcGraph = {
+  boxes: [
+    { boxId: "B1", kind: "fixed", center: { x: 0, y: 0 } },
+    { boxId: "B2", kind: "floating" },
+  ],
+  pins: [
+    {
+      boxId: "B1",
+      pinId: "P1",
+      networkId: "N1",
+      color: "red",
+      offset: { x: 1, y: 0 },
+    },
+    {
+      boxId: "B2",
+      pinId: "P2",
+      networkId: "N1",
+      color: "blue",
+      offset: { x: 0, y: 0 },
+    },
+  ],
+}
+
+test("convertFlatExample", () => {
+  const flat = convertToFlatBpcGraph(g)
+  const reconstructed = convertFromFlatBpcGraph(flat)
+
+  const svg = getSvgFromGraphicsObject(
+    stackGraphicsHorizontally([
+      getGraphicsForBpcGraph(g, { title: "Original" }),
+      getGraphicsForBpcGraph(reconstructed, { title: "Round Trip" }),
+    ]),
+    { backgroundColor: "white" },
+  )
+
+  expect(svg).toMatchSvgSnapshot(import.meta.path)
+})

--- a/tests/readme/graphUtilsExample.test.ts
+++ b/tests/readme/graphUtilsExample.test.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "bun:test"
+import {
+  stackGraphicsHorizontally,
+  getSvgFromGraphicsObject,
+} from "graphics-debug"
+import { getGraphicsForBpcGraph } from "lib/debug/getGraphicsForBpcGraph"
+import { getGraphBounds } from "lib/graph-utils/getGraphBounds"
+import { getPinPosition } from "lib/graph-utils/getPinPosition"
+import { getPinDirection } from "lib/graph-utils/getPinDirection"
+import type { BpcGraph } from "lib/types"
+
+const g: BpcGraph = {
+  boxes: [
+    { boxId: "A", kind: "fixed", center: { x: 0, y: 0 } },
+    { boxId: "B", kind: "fixed", center: { x: 2, y: 0 } },
+  ],
+  pins: [
+    {
+      boxId: "A",
+      pinId: "P1",
+      offset: { x: 0.5, y: 0 },
+      color: "red",
+      networkId: "N1",
+    },
+    {
+      boxId: "B",
+      pinId: "P1",
+      offset: { x: -0.5, y: 0 },
+      color: "red",
+      networkId: "N1",
+    },
+  ],
+}
+
+test("graphUtilsExample", () => {
+  const bounds = getGraphBounds(g)
+  const pos = getPinPosition(g, "P1")
+  const dir = getPinDirection(g, "P1")
+
+  const original = getGraphicsForBpcGraph(g, { title: "Original" })
+  const withInfo = getGraphicsForBpcGraph(g, {
+    title: "With Info",
+    caption: `bounds: [${bounds.minX}, ${bounds.minY}] - [${bounds.maxX}, ${bounds.maxY}]\nP1@${pos.x},${pos.y} dir:${dir}`,
+  })
+  withInfo.rects.push({
+    center: {
+      x: (bounds.minX + bounds.maxX) / 2,
+      y: (bounds.minY + bounds.maxY) / 2,
+    },
+    width: bounds.maxX - bounds.minX,
+    height: bounds.maxY - bounds.minY,
+    strokeColor: "green",
+    strokeWidth: 0.05,
+    fill: "transparent",
+  })
+
+  const svg = getSvgFromGraphicsObject(
+    stackGraphicsHorizontally([original, withInfo]),
+    {
+      backgroundColor: "white",
+    },
+  )
+
+  expect(svg).toMatchSvgSnapshot(import.meta.path)
+})


### PR DESCRIPTION
## Summary
- add a contents section with links to all function docs
- embed graphics for each API function
- add README snapshot tests for graph utility and flat conversion examples

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/readme/graphUtilsExample.test.ts`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/readme/convertFlatExample.test.ts`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/readme`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_6861c86abd58832eb6d47deaba0bc7d2