### PR TITLE
Add accessory corpus option

### DIFF
--- a/lib/schematic-layout/layoutSchematicGraph.ts
+++ b/lib/schematic-layout/layoutSchematicGraph.ts
@@ -14,6 +14,7 @@ export const layoutSchematicGraph = (
   g: BpcGraph,
   {
     corpus,
+    accessoryCorpus = {},
     singletonKeys,
     centerPinColors,
     floatingBoxIdsWithMutablePinOffsets,
@@ -22,6 +23,7 @@ export const layoutSchematicGraph = (
     centerPinColors?: string[]
     floatingBoxIdsWithMutablePinOffsets?: Set<FloatingBoxId>
     corpus: Record<string, FixedBpcGraph>
+    accessoryCorpus?: Record<string, FixedBpcGraph>
   },
 ): { fixedGraph: FixedBpcGraph; distance: number } => {
   const processor = new SchematicPartitionProcessor(g, {
@@ -41,7 +43,10 @@ export const layoutSchematicGraph = (
 
   /* ───────── net-adapt each canonical partition to its best corpus match ───────── */
   const adaptedGraphs = canonicalPartitions.map((part) => {
-    const { graph: corpusSource, distance } = matchGraph(part.g, corpus as any)
+    const { graph: corpusSource, distance } = matchGraph(part.g, {
+      ...corpus,
+      ...accessoryCorpus,
+    } as any)
     const adaptedBpcGraph = netAdaptBpcGraph2(
       structuredClone(part.g),
       corpusSource,

--- a/lib/schematic-layout/layoutSchematicGraphVariants.ts
+++ b/lib/schematic-layout/layoutSchematicGraphVariants.ts
@@ -6,6 +6,7 @@ export const layoutSchematicGraphVariants = (
   variants: Array<{ variantName: string; floatingGraph: BpcGraph }>,
   {
     corpus,
+    accessoryCorpus = {},
     singletonKeys,
     centerPinColors,
     floatingBoxIdsWithMutablePinOffsets,
@@ -14,6 +15,7 @@ export const layoutSchematicGraphVariants = (
     centerPinColors?: string[]
     floatingBoxIdsWithMutablePinOffsets?: Set<FloatingBoxId>
     corpus: Record<string, FixedBpcGraph>
+    accessoryCorpus?: Record<string, FixedBpcGraph>
   },
 ): {
   fixedGraph: FixedBpcGraph
@@ -32,6 +34,7 @@ export const layoutSchematicGraphVariants = (
       variant.floatingGraph,
       {
         corpus,
+        accessoryCorpus,
         singletonKeys,
         centerPinColors,
         floatingBoxIdsWithMutablePinOffsets,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.0.0",
     "@react-hook/resize-observer": "^2.0.2",
-    "@tscircuit/schematic-corpus": "^0.0.55",
+    "@tscircuit/schematic-corpus": "^0.0.72",
     "@types/bun": "latest",
     "@types/debug": "^4.1.12",
     "@vitejs/plugin-react": "^4.5.2",

--- a/tests/accessoryCorpus/accessoryCorpusOption.test.ts
+++ b/tests/accessoryCorpus/accessoryCorpusOption.test.ts
@@ -1,0 +1,97 @@
+import { test, expect } from "bun:test"
+import { layoutSchematicGraph } from "lib/index"
+import type { MixedBpcGraph, FixedBpcGraph } from "lib/types"
+
+const floatingGraph: MixedBpcGraph = {
+  boxes: [{ boxId: "U1", kind: "floating", center: { x: 0, y: 0 } }],
+  pins: [
+    {
+      boxId: "U1",
+      pinId: "L1",
+      networkId: "n1",
+      color: "c1",
+      offset: { x: -1, y: 0 },
+    },
+    {
+      boxId: "U1",
+      pinId: "L2",
+      networkId: "n2",
+      color: "c2",
+      offset: { x: -1, y: 1 },
+    },
+    {
+      boxId: "U1",
+      pinId: "R1",
+      networkId: "n3",
+      color: "c1",
+      offset: { x: 1, y: 0 },
+    },
+    {
+      boxId: "U1",
+      pinId: "R2",
+      networkId: "n4",
+      color: "c2",
+      offset: { x: 1, y: -1 },
+    },
+  ],
+}
+
+const leftCorpusGraph: FixedBpcGraph = {
+  boxes: [{ boxId: "U1", kind: "fixed", center: { x: 0, y: 0 } }],
+  pins: [
+    {
+      boxId: "U1",
+      pinId: "P1",
+      networkId: "a1",
+      color: "c1",
+      offset: { x: 1, y: 0 },
+    },
+    {
+      boxId: "U1",
+      pinId: "P2",
+      networkId: "a2",
+      color: "c2",
+      offset: { x: 1, y: 1 },
+    },
+    {
+      boxId: "U1",
+      pinId: "P3",
+      networkId: "a3",
+      color: "c3",
+      offset: { x: 1, y: 2 },
+    },
+  ],
+}
+
+const rightCorpusGraph: FixedBpcGraph = {
+  boxes: [{ boxId: "U1", kind: "fixed", center: { x: 0, y: 0 } }],
+  pins: [
+    {
+      boxId: "U1",
+      pinId: "P1",
+      networkId: "b1",
+      color: "c1",
+      offset: { x: 1, y: 0 },
+    },
+    {
+      boxId: "U1",
+      pinId: "P2",
+      networkId: "b2",
+      color: "c3",
+      offset: { x: 1, y: -1 },
+    },
+  ],
+}
+
+test("accessoryCorpus merges with main corpus", () => {
+  const resultWith = layoutSchematicGraph(floatingGraph, {
+    corpus: { left: leftCorpusGraph },
+    accessoryCorpus: { right: rightCorpusGraph },
+  })
+
+  const resultUnion = layoutSchematicGraph(floatingGraph, {
+    corpus: { left: leftCorpusGraph, right: rightCorpusGraph },
+  })
+
+  expect(resultWith.distance).toBeCloseTo(resultUnion.distance)
+})

--- a/tests/partitionGraphForLayout/__snapshots__/partitionGraphForLayout01.snap.svg
+++ b/tests/partitionGraphForLayout/__snapshots__/partitionGraphForLayout01.snap.svg
@@ -3,839 +3,839 @@
   <g>
     <circle data-type="point" data-label="U1_center
 component_center
-center_schematic_component_0" data-x="0" data-y="0" cx="286.0543225400855" cy="80.8713831835106" r="3" fill="gray" />
+center_schematic_component_0" data-x="0" data-y="0" cx="289.00476380258505" cy="80.8848929170438" r="3" fill="gray" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin1
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="-0.6" data-y="0.7" cx="266.1170624505681" cy="57.611246412407" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="-0.6" data-y="0.7" cx="269.06091359914905" cy="57.61706767970182" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin2
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="-0.6" data-y="-0.7" cx="266.1170624505681" cy="104.1315199546142" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="-0.6" data-y="-0.7" cx="269.06091359914905" cy="104.15271815438578" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin3
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="0.6" data-y="0.7" cx="305.9915826296029" cy="57.611246412407" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="0.6" data-y="0.7" cx="308.94861400602105" cy="57.61706767970182" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin4
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="0.6" data-y="-0.7" cx="305.9915826296029" cy="104.1315199546142" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="0.6" data-y="-0.7" cx="308.94861400602105" cy="104.15271815438578" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="C1_center
 component_center
-center_schematic_component_1" data-x="1" data-y="0" cx="319.28308935594777" cy="80.8713831835106" r="3" fill="gray" />
+center_schematic_component_1" data-x="1" data-y="0" cx="322.244514141645" cy="80.8848929170438" r="3" fill="gray" />
   </g>
   <g>
     <circle data-type="point" data-label="C1_pin1
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="0.999727" data-y="0.551209" cx="319.27401790260706" cy="62.55538785570597" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="0.999727" data-y="0.551209" cx="322.23543968980243" cy="62.56284337240089" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="C1_pin2
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="1.000273" data-y="-0.551209" cx="319.2921608092885" cy="99.18737851131523" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="1.000273" data-y="-0.551209" cx="322.25358859348756" cy="99.20694246168671" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL1_pin
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="-1" data-y="1" cx="252.8255557242232" cy="47.642616367648316" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="-1" data-y="1" cx="255.76501346352507" cy="47.645142577983826" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="NL1_center
 netlabel_center
-schematic_net_label_0_center" data-x="-1" data-y="1.18" cx="252.8255557242232" cy="41.661438340793104" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_0_center" data-x="-1" data-y="1.18" cx="255.76501346352507" cy="41.66198751695303" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="NL2_pin
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="-1" data-y="-1" cx="252.8255557242232" cy="114.10014999937289" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="-1" data-y="-1" cx="255.76501346352507" cy="114.12464325610378" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL2_center
 netlabel_center
-schematic_net_label_1_center" data-x="-1" data-y="-1.18" cx="252.8255557242232" cy="120.0813280262281" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_1_center" data-x="-1" data-y="-1.18" cx="255.76501346352507" cy="120.10779831713457" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="NL3_pin
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="1" data-y="1" cx="319.28308935594777" cy="47.642616367648316" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="1" data-y="1" cx="322.244514141645" cy="47.645142577983826" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="NL3_center
 netlabel_center
-schematic_net_label_2_center" data-x="1" data-y="1.18" cx="319.28308935594777" cy="41.661438340793104" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_2_center" data-x="1" data-y="1.18" cx="322.244514141645" cy="41.66198751695303" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="NL4_pin
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="1" data-y="-1" cx="319.28308935594777" cy="114.10014999937289" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="1" data-y="-1" cx="322.244514141645" cy="114.12464325610378" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL4_center
 netlabel_center
-schematic_net_label_3_center" data-x="1" data-y="-1.18" cx="319.28308935594777" cy="120.0813280262281" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_3_center" data-x="1" data-y="-1.18" cx="322.244514141645" cy="120.10779831713457" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_center
 component_center
-center_schematic_component_0" data-x="0" data-y="-3.176258648964843" cx="286.0543225400855" cy="186.41454117682918" r="3" fill="gray" />
+center_schematic_component_0" data-x="0" data-y="-3.176258648964843" cx="289.00476380258505" cy="186.46293742091513" r="3" fill="gray" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin1
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="-0.6" data-y="-2.4762586489648433" cx="266.1170624505681" cy="163.15440440572556" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="-0.6" data-y="-2.4762586489648433" cx="269.06091359914905" cy="163.19511218357314" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin2
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="-0.6" data-y="-3.8762586489648427" cx="266.1170624505681" cy="209.67467794793274" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="-0.6" data-y="-3.8762586489648427" cx="269.06091359914905" cy="209.73076265825708" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="C1_center
 component_center
-center_schematic_component_1" data-x="1" data-y="-3.176258648964843" cx="319.28308935594777" cy="186.41454117682918" r="3" fill="gray" />
+center_schematic_component_1" data-x="1" data-y="-3.176258648964843" cx="322.244514141645" cy="186.46293742091513" r="3" fill="gray" />
   </g>
   <g>
     <circle data-type="point" data-label="C1_pin1
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="0.999727" data-y="-2.625049648964843" cx="319.27401790260706" cy="168.0985458490245" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="0.999727" data-y="-2.625049648964843" cx="322.23543968980243" cy="168.1408878762722" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="C1_pin2
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="1.000273" data-y="-3.727467648964843" cx="319.2921608092885" cy="204.7305365046338" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="1.000273" data-y="-3.727467648964843" cx="322.25358859348756" cy="204.784986965558" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL1_pin
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="-1" data-y="-2.176258648964843" cx="252.8255557242232" cy="153.1857743609669" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="-1" data-y="-2.176258648964843" cx="255.76501346352507" cy="153.22318708185514" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="NL1_center
 netlabel_center
-schematic_net_label_0_center" data-x="-1" data-y="-1.996258648964843" cx="252.8255557242232" cy="147.20459633411167" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_0_center" data-x="-1" data-y="-1.996258648964843" cx="255.76501346352507" cy="147.24003202082434" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="NL2_pin
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="-1" data-y="-4.1762586489648434" cx="252.8255557242232" cy="219.64330799269146" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="-1" data-y="-4.1762586489648434" cx="255.76501346352507" cy="219.7026877599751" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL2_center
 netlabel_center
-schematic_net_label_1_center" data-x="-1" data-y="-4.356258648964843" cx="252.8255557242232" cy="225.62448601954665" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_1_center" data-x="-1" data-y="-4.356258648964843" cx="255.76501346352507" cy="225.68584282100588" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_center
 component_center
-center_schematic_component_0" data-x="1.5003075187499997" data-y="-3.176258648964843" cx="335.90769123271417" cy="186.41454117682918" r="3" fill="gray" />
+center_schematic_component_0" data-x="1.5003075187499997" data-y="-3.176258648964843" cx="338.87461115764955" cy="186.46293742091513" r="3" fill="gray" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin3
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="2.1003075187499998" data-y="-2.4762586489648433" cx="355.8449513222315" cy="163.15440440572556" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="2.1003075187499998" data-y="-2.4762586489648433" cx="358.81846136108555" cy="163.19511218357314" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin4
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="2.1003075187499998" data-y="-3.8762586489648427" cx="355.8449513222315" cy="209.67467794793274" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="2.1003075187499998" data-y="-3.8762586489648427" cx="358.81846136108555" cy="209.73076265825708" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL3_pin
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="2.5003075187499997" data-y="-2.176258648964843" cx="369.13645804857646" cy="153.1857743609669" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="2.5003075187499997" data-y="-2.176258648964843" cx="372.11436149670953" cy="153.22318708185514" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="NL3_center
 netlabel_center
-schematic_net_label_2_center" data-x="2.5003075187499997" data-y="-1.996258648964843" cx="369.13645804857646" cy="147.20459633411167" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_2_center" data-x="2.5003075187499997" data-y="-1.996258648964843" cx="372.11436149670953" cy="147.24003202082434" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="NL4_pin
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="2.5003075187499997" data-y="-4.1762586489648434" cx="369.13645804857646" cy="219.64330799269146" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="2.5003075187499997" data-y="-4.1762586489648434" cx="372.11436149670953" cy="219.7026877599751" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL4_center
 netlabel_center
-schematic_net_label_3_center" data-x="2.5003075187499997" data-y="-4.356258648964843" cx="369.13645804857646" cy="225.62448601954665" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_3_center" data-x="2.5003075187499997" data-y="-4.356258648964843" cx="372.11436149670953" cy="225.68584282100588" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_center
 component_center
-center_schematic_component_0" data-x="0.00027334999999961695" data-y="-6.36376825892578" cx="286.0634056234946" cy="292.33155472954127" r="3" fill="gray" />
+center_schematic_component_0" data-x="0.00027334999999961695" data-y="-6.36376825892578" cx="289.0138498883402" cy="292.4149610593711" r="3" fill="gray" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin1
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="0.6002733499999996" data-y="-5.66376825892578" cx="306.0006657130119" cy="269.0714179584377" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="0.6002733499999996" data-y="-5.66376825892578" cx="308.9577000917762" cy="269.1471358220291" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin2
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="0.6002733499999996" data-y="-7.06376825892578" cx="306.0006657130119" cy="315.59169150064486" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="0.6002733499999996" data-y="-7.06376825892578" cx="308.9577000917762" cy="315.68278629671306" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="C1_center
 component_center
-center_schematic_component_1" data-x="-0.9997266500000004" data-y="-6.36376825892578" cx="252.8346388076323" cy="292.33155472954127" r="3" fill="gray" />
+center_schematic_component_1" data-x="-0.9997266500000004" data-y="-6.36376825892578" cx="255.77409954928024" cy="292.4149610593711" r="3" fill="gray" />
   </g>
   <g>
     <circle data-type="point" data-label="C1_pin1
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="-0.9994536500000004" data-y="-5.81255925892578" cx="252.843710260973" cy="274.0155594017366" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="-0.9994536500000004" data-y="-5.81255925892578" cx="255.7831740011228" cy="274.09291151472814" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="C1_pin2
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="-0.9999996500000004" data-y="-6.91497725892578" cx="252.82556735429156" cy="310.64755005734594" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="-0.9999996500000004" data-y="-6.91497725892578" cx="255.76502509743767" cy="310.737010604014" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL1_pin
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="1.0002733499999996" data-y="-5.36376825892578" cx="319.2921724393569" cy="259.102787913679" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="1.0002733499999996" data-y="-5.36376825892578" cx="322.25360022740017" cy="259.17521072031116" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="NL1_center
 netlabel_center
-schematic_net_label_0_center" data-x="1.0002733499999996" data-y="-5.18376825892578" cx="319.2921724393569" cy="253.1216098868238" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_0_center" data-x="1.0002733499999996" data-y="-5.18376825892578" cx="322.25360022740017" cy="253.19205565928033" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="NL2_pin
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="1.0002733499999996" data-y="-7.36376825892578" cx="319.2921724393569" cy="325.56032154540355" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="1.0002733499999996" data-y="-7.36376825892578" cx="322.25360022740017" cy="325.65471139843106" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL2_center
 netlabel_center
-schematic_net_label_1_center" data-x="1.0002733499999996" data-y="-7.5437682589257795" cx="319.2921724393569" cy="331.5414995722588" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_1_center" data-x="1.0002733499999996" data-y="-7.5437682589257795" cx="322.25360022740017" cy="331.63786645946186" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_center
 component_center
-center_schematic_component_0" data-x="1.5003075187499997" data-y="-6.36376825892578" cx="335.90769123271417" cy="292.33155472954127" r="3" fill="gray" />
+center_schematic_component_0" data-x="1.5003075187499997" data-y="-6.36376825892578" cx="338.87461115764955" cy="292.4149610593711" r="3" fill="gray" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin3
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="2.1003075187499998" data-y="-5.66376825892578" cx="355.8449513222315" cy="269.0714179584377" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="2.1003075187499998" data-y="-5.66376825892578" cx="358.81846136108555" cy="269.1471358220291" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin4
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="2.1003075187499998" data-y="-7.06376825892578" cx="355.8449513222315" cy="315.59169150064486" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="2.1003075187499998" data-y="-7.06376825892578" cx="358.81846136108555" cy="315.68278629671306" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL3_pin
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="2.5003075187499997" data-y="-5.36376825892578" cx="369.13645804857646" cy="259.102787913679" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="2.5003075187499997" data-y="-5.36376825892578" cx="372.11436149670953" cy="259.17521072031116" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="NL3_center
 netlabel_center
-schematic_net_label_2_center" data-x="2.5003075187499997" data-y="-5.18376825892578" cx="369.13645804857646" cy="253.1216098868238" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_2_center" data-x="2.5003075187499997" data-y="-5.18376825892578" cx="372.11436149670953" cy="253.19205565928033" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="NL4_pin
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="2.5003075187499997" data-y="-7.36376825892578" cx="369.13645804857646" cy="325.56032154540355" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="2.5003075187499997" data-y="-7.36376825892578" cx="372.11436149670953" cy="325.65471139843106" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL4_center
 netlabel_center
-schematic_net_label_3_center" data-x="2.5003075187499997" data-y="-7.5437682589257795" cx="369.13645804857646" cy="331.5414995722588" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_3_center" data-x="2.5003075187499997" data-y="-7.5437682589257795" cx="372.11436149670953" cy="331.63786645946186" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_center
 component_center
-center_schematic_component_0" data-x="-1" data-y="-9.316545313671872" cx="252.8255557242232" cy="390.4486949409278" r="3" fill="gray" />
+center_schematic_component_0" data-x="-1" data-y="-9.311533438671873" cx="255.76501346352507" cy="390.3979396923055" r="3" fill="gray" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin1
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="-0.4" data-y="-8.616545313671873" cx="272.7628158137406" cy="367.1885581698242" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="-0.4" data-y="-8.611533438671874" cx="275.70886366696107" cy="367.1301144549635" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin2
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="-0.4" data-y="-10.016545313671871" cx="272.7628158137406" cy="413.7088317120314" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="-0.4" data-y="-10.011533438671872" cx="275.70886366696107" cy="413.6657649296475" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="C1_center
 component_center
-center_schematic_component_1" data-x="0.724607" data-y="-9.313102313671871" cx="310.132119576227" cy="390.33428829678076" r="3" fill="gray" />
+center_schematic_component_1" data-x="0.724607" data-y="-9.308090438671872" cx="313.09051957652025" cy="390.2834952318881" r="3" fill="gray" />
   </g>
   <g>
     <circle data-type="point" data-label="C1_pin1
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="0.7248810000000001" data-y="-8.761892313671872" cx="310.14122425833455" cy="372.0182597402093" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="0.7248810000000001" data-y="-8.756880438671873" cx="313.0996272681132" cy="371.9614124474948" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="C1_pin2
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="0.724334" data-y="-9.864311313671871" cx="310.1230481228863" cy="408.6502836245854" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="0.724334" data-y="-9.859299438671872" cx="313.0814451246777" cy="408.605544776531" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL1_pin
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="0.724607" data-y="-8.516545313671871" cx="310.132119576227" cy="363.86568148823795" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="0.724607" data-y="-8.511533438671872" cx="313.09051957652025" cy="363.8061394210574" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="NL1_center
 netlabel_center
-schematic_net_label_0_center" data-x="0.724607" data-y="-8.336545313671872" cx="310.132119576227" cy="357.88450346138274" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_0_center" data-x="0.724607" data-y="-8.331533438671872" cx="313.09051957652025" cy="357.8229843600267" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="NL2_pin
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="0.724607" data-y="-10.116545313671873" cx="310.132119576227" cy="417.03170839361763" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="0.724607" data-y="-10.111533438671874" cx="313.09051957652025" cy="416.98973996355346" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL2_center
 netlabel_center
-schematic_net_label_1_center" data-x="0.724607" data-y="-10.296545313671873" cx="310.132119576227" cy="423.01288642047285" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_1_center" data-x="0.724607" data-y="-10.291533438671873" cx="313.09051957652025" cy="422.9728950245842" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_center
 component_center
-center_schematic_component_0" data-x="1.4997499999999997" data-y="-9.516545313671871" cx="335.88916557217493" cy="397.09444830410024" r="3" fill="gray" />
+center_schematic_component_0" data-x="1.47995" data-y="-9.591533438671872" cx="338.19793231687686" cy="399.7050697872422" r="3" fill="gray" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin3
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="2.09975" data-y="-8.816545313671872" cx="355.8264256616923" cy="373.83431153299665" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="2.07995" data-y="-8.891533438671873" cx="358.14178252031286" cy="376.43724454990024" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin4
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="2.09975" data-y="-10.216545313671872" cx="355.8264256616923" cy="420.3545850752039" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="2.07995" data-y="-10.291533438671873" cx="358.14178252031286" cy="422.9728950245842" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL3_pin
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="2.7997499999999995" data-y="-8.916545313671872" cx="379.0865624327959" cy="377.1571882145829" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="2.7799500000000004" data-y="-9.191533438671874" cx="381.40960775765484" cy="386.4091696516183" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="NL3_center
 netlabel_center
-schematic_net_label_2_center" data-x="2.7997499999999995" data-y="-8.736545313671872" cx="379.0865624327959" cy="371.1760101877277" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_2_center" data-x="2.7799500000000004" data-y="-9.011533438671872" cx="381.40960775765484" cy="380.42601459058744" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="NL4_pin
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="2.7997499999999995" data-y="-10.116545313671873" cx="379.0865624327959" cy="417.03170839361763" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="2.7799500000000004" data-y="-9.991533438671873" cx="381.40960775765484" cy="413.00096992286626" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL4_center
 netlabel_center
-schematic_net_label_3_center" data-x="2.7997499999999995" data-y="-10.296545313671873" cx="379.0865624327959" cy="423.01288642047285" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_3_center" data-x="2.7799500000000004" data-y="-10.171533438671872" cx="381.40960775765484" cy="418.984124983897" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_center
 component_center
-center_schematic_component_0" data-x="0.7248806993080428" data-y="-12.006529898298417" cx="310.14121426671164" cy="479.83356544174745" r="3" fill="gray" />
+center_schematic_component_0" data-x="0.7248806993080428" data-y="-12.000961148298419" cx="313.0996172731876" cy="479.7938453152417" r="3" fill="gray" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin1
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="0.1248806993080428" data-y="-11.306529898298418" cx="290.20395417719425" cy="456.57342867064386" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="0.1248806993080428" data-y="-11.30096114829842" cx="293.1557670697516" cy="456.52602007789983" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin2
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="0.1248806993080428" data-y="-12.706529898298417" cx="290.20395417719425" cy="503.09370221285104" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="0.1248806993080428" data-y="-12.700961148298418" cx="293.1557670697516" cy="503.0616705525837" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="C1_center
 component_center
-center_schematic_component_1" data-x="-0.9997263006919572" data-y="-12.003086898298417" cx="252.83465041470782" cy="479.7191587976004" r="3" fill="gray" />
+center_schematic_component_1" data-x="-0.9997263006919572" data-y="-11.997518148298418" cx="255.77411116019238" cy="479.6794008548244" r="3" fill="gray" />
   </g>
   <g>
     <circle data-type="point" data-label="C1_pin1
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="-1.0000003006919573" data-y="-11.451876898298417" cx="252.82554573260026" cy="461.403130241029" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="-1.0000003006919573" data-y="-11.446308148298419" cx="255.76500346859947" cy="461.3573180704311" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="C1_pin2
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="-0.9994533006919573" data-y="-12.554295898298417" cx="252.84372186804853" cy="498.03515412540503" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="-0.9994533006919573" data-y="-12.548727148298418" cx="255.78318561203494" cy="498.0014503994672" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL1_pin
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="-0.9997263006919572" data-y="-11.206529898298417" cx="252.83465041470782" cy="453.2505519890576" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="-0.9997263006919572" data-y="-11.200961148298418" cx="255.77411116019238" cy="453.20204504399373" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="NL1_center
 netlabel_center
-schematic_net_label_0_center" data-x="-0.9997263006919572" data-y="-11.026529898298417" cx="252.83465041470782" cy="447.2693739622024" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_0_center" data-x="-0.9997263006919572" data-y="-11.020961148298419" cx="255.77411116019238" cy="447.218889982963" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="NL2_pin
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="-0.9997263006919572" data-y="-12.806529898298418" cx="252.83465041470782" cy="506.4165788944373" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="-0.9997263006919572" data-y="-12.80096114829842" cx="255.77411116019238" cy="506.3856455864898" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL2_center
 netlabel_center
-schematic_net_label_1_center" data-x="-0.9997263006919572" data-y="-12.986529898298418" cx="252.83465041470782" cy="512.3977569212925" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_1_center" data-x="-0.9997263006919572" data-y="-12.98096114829842" cx="255.77411116019238" cy="512.3688006475205" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_center
 component_center
-center_schematic_component_0" data-x="1.227990786721548" data-y="-12.206529898298417" cx="326.85894204408305" cy="486.4793188049199" r="3" fill="gray" />
+center_schematic_component_0" data-x="1.227990786721548" data-y="-12.280961148298418" cx="329.82287097187515" cy="489.10097541017853" r="3" fill="gray" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin3
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="1.8279907867215481" data-y="-11.506529898298417" cx="346.79620213360045" cy="463.2191820338163" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="1.8279907867215481" data-y="-11.58096114829842" cx="349.76672117531115" cy="465.83315017283655" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin4
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="1.8279907867215481" data-y="-12.906529898298418" cx="346.79620213360045" cy="509.73945557602354" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="1.8279907867215481" data-y="-12.98096114829842" cx="349.76672117531115" cy="512.3688006475205" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL3_pin
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="2.5279907867215483" data-y="-11.606529898298417" cx="370.05633890470403" cy="466.5420587154025" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="2.5279907867215483" data-y="-11.88096114829842" cx="373.0345464126531" cy="475.8050752745546" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="NL3_center
 netlabel_center
-schematic_net_label_2_center" data-x="2.5279907867215483" data-y="-11.426529898298417" cx="370.05633890470403" cy="460.56088068854734" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_2_center" data-x="2.5279907867215483" data-y="-11.700961148298418" cx="373.0345464126531" cy="469.82192021352375" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="NL4_pin
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="2.5279907867215483" data-y="-12.806529898298418" cx="370.05633890470403" cy="506.4165788944373" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="2.5279907867215483" data-y="-12.680961148298419" cx="373.0345464126531" cy="502.3968755458026" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL4_center
 netlabel_center
-schematic_net_label_3_center" data-x="2.5279907867215483" data-y="-12.986529898298418" cx="370.05633890470403" cy="512.3977569212925" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_3_center" data-x="2.5279907867215483" data-y="-12.860961148298419" cx="373.0345464126531" cy="508.3800306068333" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_center
 component_center
-center_schematic_component_0" data-x="0.7248806993080428" data-y="-14.592867369506923" cx="310.14121426671164" cy="565.7743701796618" r="3" fill="gray" />
+center_schematic_component_0" data-x="0.7248806993080428" data-y="-14.587298619506925" cx="313.0996172731876" cy="565.7630571507682" r="3" fill="gray" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin1
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="0.1248806993080428" data-y="-13.892867369506924" cx="290.20395417719425" cy="542.5142334085583" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="0.1248806993080428" data-y="-13.887298619506925" cx="293.1557670697516" cy="542.4952319134262" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin2
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="0.1248806993080428" data-y="-15.292867369506922" cx="290.20395417719425" cy="589.0345069507654" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="0.1248806993080428" data-y="-15.287298619506924" cx="293.1557670697516" cy="589.0308823881102" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin3
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="1.3248806993080429" data-y="-13.892867369506924" cx="330.078474356229" cy="542.5142334085583" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="1.3248806993080429" data-y="-13.887298619506925" cx="333.04346747662356" cy="542.4952319134262" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="U1_pin4
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="1.3248806993080429" data-y="-15.292867369506922" cx="330.078474356229" cy="589.0345069507654" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="1.3248806993080429" data-y="-15.287298619506924" cx="333.04346747662356" cy="589.0308823881102" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="C1_center
 component_center
-center_schematic_component_1" data-x="-0.9997263006919572" data-y="-14.589424369506922" cx="252.83465041470782" cy="565.6599635355147" r="3" fill="gray" />
+center_schematic_component_1" data-x="-0.9997263006919572" data-y="-14.583855619506924" cx="255.77411116019238" cy="565.6486126903508" r="3" fill="gray" />
   </g>
   <g>
     <circle data-type="point" data-label="C1_pin1
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="-1.0000003006919573" data-y="-14.038214369506923" cx="252.82554573260026" cy="547.3439349789434" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="-1.0000003006919573" data-y="-14.032645619506924" cx="255.76500346859947" cy="547.3265299059575" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="C1_pin2
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="-0.9994533006919573" data-y="-15.140633369506922" cx="252.84372186804853" cy="583.9759588633194" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="-0.9994533006919573" data-y="-15.135064619506924" cx="255.78318561203494" cy="583.9706622349937" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL1_pin
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="-0.9997263006919572" data-y="-13.792867369506922" cx="252.83465041470782" cy="539.1913567269719" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="-0.9997263006919572" data-y="-13.787298619506924" cx="255.77411116019238" cy="539.1712568795202" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="NL1_center
 netlabel_center
-schematic_net_label_0_center" data-x="-0.9997263006919572" data-y="-13.612867369506922" cx="252.83465041470782" cy="533.2101787001168" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_0_center" data-x="-0.9997263006919572" data-y="-13.607298619506924" cx="255.77411116019238" cy="533.1881018184894" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="NL2_pin
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="-0.9997263006919572" data-y="-15.392867369506924" cx="252.83465041470782" cy="592.3573836323517" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="-0.9997263006919572" data-y="-15.387298619506925" cx="255.77411116019238" cy="592.3548574220162" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL2_center
 netlabel_center
-schematic_net_label_1_center" data-x="-0.9997263006919572" data-y="-15.572867369506923" cx="252.83465041470782" cy="598.3385616592069" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_1_center" data-x="-0.9997263006919572" data-y="-15.567298619506925" cx="255.77411116019238" cy="598.3380124830469" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="NL3_pin
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="2.024880699308043" data-y="-13.992867369506923" cx="353.33861112733257" cy="545.8371100901445" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="2.024880699308043" data-y="-14.187298619506924" cx="356.3112927139656" cy="552.4671570151442" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="NL3_center
 netlabel_center
-schematic_net_label_2_center" data-x="2.024880699308043" data-y="-13.812867369506924" cx="353.33861112733257" cy="539.8559320632892" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_2_center" data-x="2.024880699308043" data-y="-14.007298619506924" cx="356.3112927139656" cy="546.4840019541134" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="NL4_pin
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="2.024880699308043" data-y="-15.192867369506923" cx="353.33861112733257" cy="585.7116302691792" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="2.024880699308043" data-y="-14.987298619506925" cx="356.3112927139656" cy="579.0589572863922" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL4_center
 netlabel_center
-schematic_net_label_3_center" data-x="2.024880699308043" data-y="-15.372867369506922" cx="353.33861112733257" cy="591.6928082960344" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_3_center" data-x="2.024880699308043" data-y="-15.167298619506925" cx="356.3112927139656" cy="585.042112347423" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
-    <polyline data-points="-0.6,0.7 0.6,0.7" data-type="line" data-label="" points="266.1170624505681,57.611246412407 305.9915826296029,57.611246412407" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.6,0.7 0.6,0.7" data-type="line" data-label="" points="269.06091359914905,57.61706767970182 308.94861400602105,57.61706767970182" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.6,0.7 0.999727,0.551209" data-type="line" data-label="" points="266.1170624505681,57.611246412407 319.27401790260706,62.55538785570597" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.6,0.7 0.999727,0.551209" data-type="line" data-label="" points="269.06091359914905,57.61706767970182 322.23543968980243,62.56284337240089" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.6,0.7 -1,1" data-type="line" data-label="" points="266.1170624505681,57.611246412407 252.8255557242232,47.642616367648316" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.6,0.7 -1,1" data-type="line" data-label="" points="269.06091359914905,57.61706767970182 255.76501346352507,47.645142577983826" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.6,0.7 1,1" data-type="line" data-label="" points="266.1170624505681,57.611246412407 319.28308935594777,47.642616367648316" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.6,0.7 1,1" data-type="line" data-label="" points="269.06091359914905,57.61706767970182 322.244514141645,47.645142577983826" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.6,0.7 0.999727,0.551209" data-type="line" data-label="" points="305.9915826296029,57.611246412407 319.27401790260706,62.55538785570597" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.6,0.7 0.999727,0.551209" data-type="line" data-label="" points="308.94861400602105,57.61706767970182 322.23543968980243,62.56284337240089" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.6,0.7 -1,1" data-type="line" data-label="" points="305.9915826296029,57.611246412407 252.8255557242232,47.642616367648316" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.6,0.7 -1,1" data-type="line" data-label="" points="308.94861400602105,57.61706767970182 255.76501346352507,47.645142577983826" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.6,0.7 1,1" data-type="line" data-label="" points="305.9915826296029,57.611246412407 319.28308935594777,47.642616367648316" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.6,0.7 1,1" data-type="line" data-label="" points="308.94861400602105,57.61706767970182 322.244514141645,47.645142577983826" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.999727,0.551209 -1,1" data-type="line" data-label="" points="319.27401790260706,62.55538785570597 252.8255557242232,47.642616367648316" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.999727,0.551209 -1,1" data-type="line" data-label="" points="322.23543968980243,62.56284337240089 255.76501346352507,47.645142577983826" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.999727,0.551209 1,1" data-type="line" data-label="" points="319.27401790260706,62.55538785570597 319.28308935594777,47.642616367648316" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.999727,0.551209 1,1" data-type="line" data-label="" points="322.23543968980243,62.56284337240089 322.244514141645,47.645142577983826" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-1,1 1,1" data-type="line" data-label="" points="252.8255557242232,47.642616367648316 319.28308935594777,47.642616367648316" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-1,1 1,1" data-type="line" data-label="" points="255.76501346352507,47.645142577983826 322.244514141645,47.645142577983826" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.6,-0.7 0.6,-0.7" data-type="line" data-label="" points="266.1170624505681,104.1315199546142 305.9915826296029,104.1315199546142" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.6,-0.7 0.6,-0.7" data-type="line" data-label="" points="269.06091359914905,104.15271815438578 308.94861400602105,104.15271815438578" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.6,-0.7 1.000273,-0.551209" data-type="line" data-label="" points="266.1170624505681,104.1315199546142 319.2921608092885,99.18737851131523" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.6,-0.7 1.000273,-0.551209" data-type="line" data-label="" points="269.06091359914905,104.15271815438578 322.25358859348756,99.20694246168671" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.6,-0.7 -1,-1" data-type="line" data-label="" points="266.1170624505681,104.1315199546142 252.8255557242232,114.10014999937289" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.6,-0.7 -1,-1" data-type="line" data-label="" points="269.06091359914905,104.15271815438578 255.76501346352507,114.12464325610378" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.6,-0.7 1,-1" data-type="line" data-label="" points="266.1170624505681,104.1315199546142 319.28308935594777,114.10014999937289" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.6,-0.7 1,-1" data-type="line" data-label="" points="269.06091359914905,104.15271815438578 322.244514141645,114.12464325610378" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.6,-0.7 1.000273,-0.551209" data-type="line" data-label="" points="305.9915826296029,104.1315199546142 319.2921608092885,99.18737851131523" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.6,-0.7 1.000273,-0.551209" data-type="line" data-label="" points="308.94861400602105,104.15271815438578 322.25358859348756,99.20694246168671" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.6,-0.7 -1,-1" data-type="line" data-label="" points="305.9915826296029,104.1315199546142 252.8255557242232,114.10014999937289" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.6,-0.7 -1,-1" data-type="line" data-label="" points="308.94861400602105,104.15271815438578 255.76501346352507,114.12464325610378" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.6,-0.7 1,-1" data-type="line" data-label="" points="305.9915826296029,104.1315199546142 319.28308935594777,114.10014999937289" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.6,-0.7 1,-1" data-type="line" data-label="" points="308.94861400602105,104.15271815438578 322.244514141645,114.12464325610378" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="1.000273,-0.551209 -1,-1" data-type="line" data-label="" points="319.2921608092885,99.18737851131523 252.8255557242232,114.10014999937289" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="1.000273,-0.551209 -1,-1" data-type="line" data-label="" points="322.25358859348756,99.20694246168671 255.76501346352507,114.12464325610378" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="1.000273,-0.551209 1,-1" data-type="line" data-label="" points="319.2921608092885,99.18737851131523 319.28308935594777,114.10014999937289" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="1.000273,-0.551209 1,-1" data-type="line" data-label="" points="322.25358859348756,99.20694246168671 322.244514141645,114.12464325610378" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-1,-1 1,-1" data-type="line" data-label="" points="252.8255557242232,114.10014999937289 319.28308935594777,114.10014999937289" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-1,-1 1,-1" data-type="line" data-label="" points="255.76501346352507,114.12464325610378 322.244514141645,114.12464325610378" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.6,-2.4762586489648433 0.999727,-2.625049648964843" data-type="line" data-label="" points="266.1170624505681,163.15440440572556 319.27401790260706,168.0985458490245" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.6,-2.4762586489648433 0.999727,-2.625049648964843" data-type="line" data-label="" points="269.06091359914905,163.19511218357314 322.23543968980243,168.1408878762722" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.6,-2.4762586489648433 -1,-2.176258648964843" data-type="line" data-label="" points="266.1170624505681,163.15440440572556 252.8255557242232,153.1857743609669" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.6,-2.4762586489648433 -1,-2.176258648964843" data-type="line" data-label="" points="269.06091359914905,163.19511218357314 255.76501346352507,153.22318708185514" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.999727,-2.625049648964843 -1,-2.176258648964843" data-type="line" data-label="" points="319.27401790260706,168.0985458490245 252.8255557242232,153.1857743609669" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.999727,-2.625049648964843 -1,-2.176258648964843" data-type="line" data-label="" points="322.23543968980243,168.1408878762722 255.76501346352507,153.22318708185514" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.6,-3.8762586489648427 1.000273,-3.727467648964843" data-type="line" data-label="" points="266.1170624505681,209.67467794793274 319.2921608092885,204.7305365046338" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.6,-3.8762586489648427 1.000273,-3.727467648964843" data-type="line" data-label="" points="269.06091359914905,209.73076265825708 322.25358859348756,204.784986965558" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.6,-3.8762586489648427 -1,-4.1762586489648434" data-type="line" data-label="" points="266.1170624505681,209.67467794793274 252.8255557242232,219.64330799269146" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.6,-3.8762586489648427 -1,-4.1762586489648434" data-type="line" data-label="" points="269.06091359914905,209.73076265825708 255.76501346352507,219.7026877599751" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="1.000273,-3.727467648964843 -1,-4.1762586489648434" data-type="line" data-label="" points="319.2921608092885,204.7305365046338 252.8255557242232,219.64330799269146" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="1.000273,-3.727467648964843 -1,-4.1762586489648434" data-type="line" data-label="" points="322.25358859348756,204.784986965558 255.76501346352507,219.7026877599751" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="2.1003075187499998,-2.4762586489648433 2.5003075187499997,-2.176258648964843" data-type="line" data-label="" points="355.8449513222315,163.15440440572556 369.13645804857646,153.1857743609669" fill="none" stroke="hsl(72, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="2.1003075187499998,-2.4762586489648433 2.5003075187499997,-2.176258648964843" data-type="line" data-label="" points="358.81846136108555,163.19511218357314 372.11436149670953,153.22318708185514" fill="none" stroke="hsl(72, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="2.1003075187499998,-3.8762586489648427 2.5003075187499997,-4.1762586489648434" data-type="line" data-label="" points="355.8449513222315,209.67467794793274 369.13645804857646,219.64330799269146" fill="none" stroke="hsl(144, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="2.1003075187499998,-3.8762586489648427 2.5003075187499997,-4.1762586489648434" data-type="line" data-label="" points="358.81846136108555,209.73076265825708 372.11436149670953,219.7026877599751" fill="none" stroke="hsl(144, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.6002733499999996,-5.66376825892578 -0.9994536500000004,-5.81255925892578" data-type="line" data-label="" points="306.0006657130119,269.0714179584377 252.843710260973,274.0155594017366" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.6002733499999996,-5.66376825892578 -0.9994536500000004,-5.81255925892578" data-type="line" data-label="" points="308.9577000917762,269.1471358220291 255.7831740011228,274.09291151472814" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.6002733499999996,-5.66376825892578 1.0002733499999996,-5.36376825892578" data-type="line" data-label="" points="306.0006657130119,269.0714179584377 319.2921724393569,259.102787913679" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.6002733499999996,-5.66376825892578 1.0002733499999996,-5.36376825892578" data-type="line" data-label="" points="308.9577000917762,269.1471358220291 322.25360022740017,259.17521072031116" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.9994536500000004,-5.81255925892578 1.0002733499999996,-5.36376825892578" data-type="line" data-label="" points="252.843710260973,274.0155594017366 319.2921724393569,259.102787913679" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.9994536500000004,-5.81255925892578 1.0002733499999996,-5.36376825892578" data-type="line" data-label="" points="255.7831740011228,274.09291151472814 322.25360022740017,259.17521072031116" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.6002733499999996,-7.06376825892578 -0.9999996500000004,-6.91497725892578" data-type="line" data-label="" points="306.0006657130119,315.59169150064486 252.82556735429156,310.64755005734594" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.6002733499999996,-7.06376825892578 -0.9999996500000004,-6.91497725892578" data-type="line" data-label="" points="308.9577000917762,315.68278629671306 255.76502509743767,310.737010604014" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.6002733499999996,-7.06376825892578 1.0002733499999996,-7.36376825892578" data-type="line" data-label="" points="306.0006657130119,315.59169150064486 319.2921724393569,325.56032154540355" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.6002733499999996,-7.06376825892578 1.0002733499999996,-7.36376825892578" data-type="line" data-label="" points="308.9577000917762,315.68278629671306 322.25360022740017,325.65471139843106" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.9999996500000004,-6.91497725892578 1.0002733499999996,-7.36376825892578" data-type="line" data-label="" points="252.82556735429156,310.64755005734594 319.2921724393569,325.56032154540355" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.9999996500000004,-6.91497725892578 1.0002733499999996,-7.36376825892578" data-type="line" data-label="" points="255.76502509743767,310.737010604014 322.25360022740017,325.65471139843106" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="2.1003075187499998,-5.66376825892578 2.5003075187499997,-5.36376825892578" data-type="line" data-label="" points="355.8449513222315,269.0714179584377 369.13645804857646,259.102787913679" fill="none" stroke="hsl(72, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="2.1003075187499998,-5.66376825892578 2.5003075187499997,-5.36376825892578" data-type="line" data-label="" points="358.81846136108555,269.1471358220291 372.11436149670953,259.17521072031116" fill="none" stroke="hsl(72, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="2.1003075187499998,-7.06376825892578 2.5003075187499997,-7.36376825892578" data-type="line" data-label="" points="355.8449513222315,315.59169150064486 369.13645804857646,325.56032154540355" fill="none" stroke="hsl(144, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="2.1003075187499998,-7.06376825892578 2.5003075187499997,-7.36376825892578" data-type="line" data-label="" points="358.81846136108555,315.68278629671306 372.11436149670953,325.65471139843106" fill="none" stroke="hsl(144, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.4,-8.616545313671873 0.7248810000000001,-8.761892313671872" data-type="line" data-label="" points="272.7628158137406,367.1885581698242 310.14122425833455,372.0182597402093" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.4,-8.611533438671874 0.7248810000000001,-8.756880438671873" data-type="line" data-label="" points="275.70886366696107,367.1301144549635 313.0996272681132,371.9614124474948" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.4,-8.616545313671873 0.724607,-8.516545313671871" data-type="line" data-label="" points="272.7628158137406,367.1885581698242 310.132119576227,363.86568148823795" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.4,-8.611533438671874 0.724607,-8.511533438671872" data-type="line" data-label="" points="275.70886366696107,367.1301144549635 313.09051957652025,363.8061394210574" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.7248810000000001,-8.761892313671872 0.724607,-8.516545313671871" data-type="line" data-label="" points="310.14122425833455,372.0182597402093 310.132119576227,363.86568148823795" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.7248810000000001,-8.756880438671873 0.724607,-8.511533438671872" data-type="line" data-label="" points="313.0996272681132,371.9614124474948 313.09051957652025,363.8061394210574" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.4,-10.016545313671871 0.724334,-9.864311313671871" data-type="line" data-label="" points="272.7628158137406,413.7088317120314 310.1230481228863,408.6502836245854" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.4,-10.011533438671872 0.724334,-9.859299438671872" data-type="line" data-label="" points="275.70886366696107,413.6657649296475 313.0814451246777,408.605544776531" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.4,-10.016545313671871 0.724607,-10.116545313671873" data-type="line" data-label="" points="272.7628158137406,413.7088317120314 310.132119576227,417.03170839361763" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.4,-10.011533438671872 0.724607,-10.111533438671874" data-type="line" data-label="" points="275.70886366696107,413.6657649296475 313.09051957652025,416.98973996355346" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.724334,-9.864311313671871 0.724607,-10.116545313671873" data-type="line" data-label="" points="310.1230481228863,408.6502836245854 310.132119576227,417.03170839361763" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.724334,-9.859299438671872 0.724607,-10.111533438671874" data-type="line" data-label="" points="313.0814451246777,408.605544776531 313.09051957652025,416.98973996355346" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="2.09975,-8.816545313671872 2.7997499999999995,-8.916545313671872" data-type="line" data-label="" points="355.8264256616923,373.83431153299665 379.0865624327959,377.1571882145829" fill="none" stroke="hsl(72, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="2.07995,-8.891533438671873 2.7799500000000004,-9.191533438671874" data-type="line" data-label="" points="358.14178252031286,376.43724454990024 381.40960775765484,386.4091696516183" fill="none" stroke="hsl(72, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="2.09975,-10.216545313671872 2.7997499999999995,-10.116545313671873" data-type="line" data-label="" points="355.8264256616923,420.3545850752039 379.0865624327959,417.03170839361763" fill="none" stroke="hsl(144, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="2.07995,-10.291533438671873 2.7799500000000004,-9.991533438671873" data-type="line" data-label="" points="358.14178252031286,422.9728950245842 381.40960775765484,413.00096992286626" fill="none" stroke="hsl(144, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.1248806993080428,-11.306529898298418 -1.0000003006919573,-11.451876898298417" data-type="line" data-label="" points="290.20395417719425,456.57342867064386 252.82554573260026,461.403130241029" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.1248806993080428,-11.30096114829842 -1.0000003006919573,-11.446308148298419" data-type="line" data-label="" points="293.1557670697516,456.52602007789983 255.76500346859947,461.3573180704311" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.1248806993080428,-11.306529898298418 -0.9997263006919572,-11.206529898298417" data-type="line" data-label="" points="290.20395417719425,456.57342867064386 252.83465041470782,453.2505519890576" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.1248806993080428,-11.30096114829842 -0.9997263006919572,-11.200961148298418" data-type="line" data-label="" points="293.1557670697516,456.52602007789983 255.77411116019238,453.20204504399373" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-1.0000003006919573,-11.451876898298417 -0.9997263006919572,-11.206529898298417" data-type="line" data-label="" points="252.82554573260026,461.403130241029 252.83465041470782,453.2505519890576" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-1.0000003006919573,-11.446308148298419 -0.9997263006919572,-11.200961148298418" data-type="line" data-label="" points="255.76500346859947,461.3573180704311 255.77411116019238,453.20204504399373" fill="none" stroke="hsl(60, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.1248806993080428,-12.706529898298417 -0.9994533006919573,-12.554295898298417" data-type="line" data-label="" points="290.20395417719425,503.09370221285104 252.84372186804853,498.03515412540503" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.1248806993080428,-12.700961148298418 -0.9994533006919573,-12.548727148298418" data-type="line" data-label="" points="293.1557670697516,503.0616705525837 255.78318561203494,498.0014503994672" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.1248806993080428,-12.706529898298417 -0.9997263006919572,-12.806529898298418" data-type="line" data-label="" points="290.20395417719425,503.09370221285104 252.83465041470782,506.4165788944373" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.1248806993080428,-12.700961148298418 -0.9997263006919572,-12.80096114829842" data-type="line" data-label="" points="293.1557670697516,503.0616705525837 255.77411116019238,506.3856455864898" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.9994533006919573,-12.554295898298417 -0.9997263006919572,-12.806529898298418" data-type="line" data-label="" points="252.84372186804853,498.03515412540503 252.83465041470782,506.4165788944373" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.9994533006919573,-12.548727148298418 -0.9997263006919572,-12.80096114829842" data-type="line" data-label="" points="255.78318561203494,498.0014503994672 255.77411116019238,506.3856455864898" fill="none" stroke="hsl(120, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="1.8279907867215481,-11.506529898298417 2.5279907867215483,-11.606529898298417" data-type="line" data-label="" points="346.79620213360045,463.2191820338163 370.05633890470403,466.5420587154025" fill="none" stroke="hsl(72, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="1.8279907867215481,-11.58096114829842 2.5279907867215483,-11.88096114829842" data-type="line" data-label="" points="349.76672117531115,465.83315017283655 373.0345464126531,475.8050752745546" fill="none" stroke="hsl(72, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="1.8279907867215481,-12.906529898298418 2.5279907867215483,-12.806529898298418" data-type="line" data-label="" points="346.79620213360045,509.73945557602354 370.05633890470403,506.4165788944373" fill="none" stroke="hsl(144, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="1.8279907867215481,-12.98096114829842 2.5279907867215483,-12.680961148298419" data-type="line" data-label="" points="349.76672117531115,512.3688006475205 373.0345464126531,502.3968755458026" fill="none" stroke="hsl(144, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.1248806993080428,-13.892867369506924 -1.0000003006919573,-14.038214369506923" data-type="line" data-label="" points="290.20395417719425,542.5142334085583 252.82554573260026,547.3439349789434" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.1248806993080428,-13.887298619506925 -1.0000003006919573,-14.032645619506924" data-type="line" data-label="" points="293.1557670697516,542.4952319134262 255.76500346859947,547.3265299059575" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.1248806993080428,-13.892867369506924 -0.9997263006919572,-13.792867369506922" data-type="line" data-label="" points="290.20395417719425,542.5142334085583 252.83465041470782,539.1913567269719" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.1248806993080428,-13.887298619506925 -0.9997263006919572,-13.787298619506924" data-type="line" data-label="" points="293.1557670697516,542.4952319134262 255.77411116019238,539.1712568795202" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.1248806993080428,-13.892867369506924 1.3248806993080429,-13.892867369506924" data-type="line" data-label="" points="290.20395417719425,542.5142334085583 330.078474356229,542.5142334085583" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.1248806993080428,-13.887298619506925 1.3248806993080429,-13.887298619506925" data-type="line" data-label="" points="293.1557670697516,542.4952319134262 333.04346747662356,542.4952319134262" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.1248806993080428,-13.892867369506924 2.024880699308043,-13.992867369506923" data-type="line" data-label="" points="290.20395417719425,542.5142334085583 353.33861112733257,545.8371100901445" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.1248806993080428,-13.887298619506925 2.024880699308043,-14.187298619506924" data-type="line" data-label="" points="293.1557670697516,542.4952319134262 356.3112927139656,552.4671570151442" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-1.0000003006919573,-14.038214369506923 -0.9997263006919572,-13.792867369506922" data-type="line" data-label="" points="252.82554573260026,547.3439349789434 252.83465041470782,539.1913567269719" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-1.0000003006919573,-14.032645619506924 -0.9997263006919572,-13.787298619506924" data-type="line" data-label="" points="255.76500346859947,547.3265299059575 255.77411116019238,539.1712568795202" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-1.0000003006919573,-14.038214369506923 1.3248806993080429,-13.892867369506924" data-type="line" data-label="" points="252.82554573260026,547.3439349789434 330.078474356229,542.5142334085583" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-1.0000003006919573,-14.032645619506924 1.3248806993080429,-13.887298619506925" data-type="line" data-label="" points="255.76500346859947,547.3265299059575 333.04346747662356,542.4952319134262" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-1.0000003006919573,-14.038214369506923 2.024880699308043,-13.992867369506923" data-type="line" data-label="" points="252.82554573260026,547.3439349789434 353.33861112733257,545.8371100901445" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-1.0000003006919573,-14.032645619506924 2.024880699308043,-14.187298619506924" data-type="line" data-label="" points="255.76500346859947,547.3265299059575 356.3112927139656,552.4671570151442" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.9997263006919572,-13.792867369506922 1.3248806993080429,-13.892867369506924" data-type="line" data-label="" points="252.83465041470782,539.1913567269719 330.078474356229,542.5142334085583" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.9997263006919572,-13.787298619506924 1.3248806993080429,-13.887298619506925" data-type="line" data-label="" points="255.77411116019238,539.1712568795202 333.04346747662356,542.4952319134262" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.9997263006919572,-13.792867369506922 2.024880699308043,-13.992867369506923" data-type="line" data-label="" points="252.83465041470782,539.1913567269719 353.33861112733257,545.8371100901445" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.9997263006919572,-13.787298619506924 2.024880699308043,-14.187298619506924" data-type="line" data-label="" points="255.77411116019238,539.1712568795202 356.3112927139656,552.4671570151442" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="1.3248806993080429,-13.892867369506924 2.024880699308043,-13.992867369506923" data-type="line" data-label="" points="330.078474356229,542.5142334085583 353.33861112733257,545.8371100901445" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="1.3248806993080429,-13.887298619506925 2.024880699308043,-14.187298619506924" data-type="line" data-label="" points="333.04346747662356,542.4952319134262 356.3112927139656,552.4671570151442" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.1248806993080428,-15.292867369506922 -0.9994533006919573,-15.140633369506922" data-type="line" data-label="" points="290.20395417719425,589.0345069507654 252.84372186804853,583.9759588633194" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.1248806993080428,-15.287298619506924 -0.9994533006919573,-15.135064619506924" data-type="line" data-label="" points="293.1557670697516,589.0308823881102 255.78318561203494,583.9706622349937" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.1248806993080428,-15.292867369506922 -0.9997263006919572,-15.392867369506924" data-type="line" data-label="" points="290.20395417719425,589.0345069507654 252.83465041470782,592.3573836323517" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.1248806993080428,-15.287298619506924 -0.9997263006919572,-15.387298619506925" data-type="line" data-label="" points="293.1557670697516,589.0308823881102 255.77411116019238,592.3548574220162" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.1248806993080428,-15.292867369506922 1.3248806993080429,-15.292867369506922" data-type="line" data-label="" points="290.20395417719425,589.0345069507654 330.078474356229,589.0345069507654" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.1248806993080428,-15.287298619506924 1.3248806993080429,-15.287298619506924" data-type="line" data-label="" points="293.1557670697516,589.0308823881102 333.04346747662356,589.0308823881102" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.1248806993080428,-15.292867369506922 2.024880699308043,-15.192867369506923" data-type="line" data-label="" points="290.20395417719425,589.0345069507654 353.33861112733257,585.7116302691792" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.1248806993080428,-15.287298619506924 2.024880699308043,-14.987298619506925" data-type="line" data-label="" points="293.1557670697516,589.0308823881102 356.3112927139656,579.0589572863922" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.9994533006919573,-15.140633369506922 -0.9997263006919572,-15.392867369506924" data-type="line" data-label="" points="252.84372186804853,583.9759588633194 252.83465041470782,592.3573836323517" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.9994533006919573,-15.135064619506924 -0.9997263006919572,-15.387298619506925" data-type="line" data-label="" points="255.78318561203494,583.9706622349937 255.77411116019238,592.3548574220162" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.9994533006919573,-15.140633369506922 1.3248806993080429,-15.292867369506922" data-type="line" data-label="" points="252.84372186804853,583.9759588633194 330.078474356229,589.0345069507654" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.9994533006919573,-15.135064619506924 1.3248806993080429,-15.287298619506924" data-type="line" data-label="" points="255.78318561203494,583.9706622349937 333.04346747662356,589.0308823881102" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.9994533006919573,-15.140633369506922 2.024880699308043,-15.192867369506923" data-type="line" data-label="" points="252.84372186804853,583.9759588633194 353.33861112733257,585.7116302691792" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.9994533006919573,-15.135064619506924 2.024880699308043,-14.987298619506925" data-type="line" data-label="" points="255.78318561203494,583.9706622349937 356.3112927139656,579.0589572863922" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.9997263006919572,-15.392867369506924 1.3248806993080429,-15.292867369506922" data-type="line" data-label="" points="252.83465041470782,592.3573836323517 330.078474356229,589.0345069507654" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.9997263006919572,-15.387298619506925 1.3248806993080429,-15.287298619506924" data-type="line" data-label="" points="255.77411116019238,592.3548574220162 333.04346747662356,589.0308823881102" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.9997263006919572,-15.392867369506924 2.024880699308043,-15.192867369506923" data-type="line" data-label="" points="252.83465041470782,592.3573836323517 353.33861112733257,585.7116302691792" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.9997263006919572,-15.387298619506925 2.024880699308043,-14.987298619506925" data-type="line" data-label="" points="255.77411116019238,592.3548574220162 356.3112927139656,579.0589572863922" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="1.3248806993080429,-15.292867369506922 2.024880699308043,-15.192867369506923" data-type="line" data-label="" points="330.078474356229,589.0345069507654 353.33861112733257,585.7116302691792" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="1.3248806993080429,-15.287298619506924 2.024880699308043,-14.987298619506925" data-type="line" data-label="" points="333.04346747662356,589.0308823881102 356.3112927139656,579.0589572863922" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <rect data-type="rect" data-label="U1" data-x="0" data-y="0" x="264.455624109775" y="55.94980807161389" width="43.197396860620984" height="49.84315022379343" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="U1" data-x="0" data-y="0" x="267.39892608219606" y="55.95508016274882" width="43.21167544077798" height="49.85962550858995" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="C1" data-x="1" data-y="0" x="317.61256793174556" y="60.893939546282795" width="3.3410428484044132" height="39.954887274455615" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="C1" data-x="1" data-y="0" x="320.57344053893684" y="60.90084588352278" width="3.3421472054163246" height="39.968094067042045" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL1" data-x="-1" data-y="1.0899999999999999" x="251.16411738343007" y="40" width="3.3228766815862514" height="9.304054708441427" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL1" data-x="-1" data-y="1.0899999999999999" x="254.10302594657207" y="40.00000000000004" width="3.323975033905981" height="9.307130094936781" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL2" data-x="-1" data-y="-1.0899999999999999" x="251.16411738343007" y="112.43871165857978" width="3.3228766815862514" height="9.304054708441427" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL2" data-x="-1" data-y="-1.0899999999999999" x="254.10302594657207" y="112.46265573915078" width="3.323975033905981" height="9.307130094936781" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL3" data-x="1" data-y="1.0899999999999999" x="317.62165101515467" y="40" width="3.3228766815861945" height="9.304054708441427" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL3" data-x="1" data-y="1.0899999999999999" x="320.58252662469204" y="40.00000000000004" width="3.323975033905981" height="9.307130094936781" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL4" data-x="1" data-y="-1.0899999999999999" x="317.62165101515467" y="112.43871165857978" width="3.3228766815861945" height="9.304054708441427" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL4" data-x="1" data-y="-1.0899999999999999" x="320.58252662469204" y="112.46265573915078" width="3.323975033905981" height="9.307130094936781" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="U1" data-x="-0.30000000000000004" data-y="-3.176258648964843" x="264.455624109775" y="161.49296606493243" width="23.26013677110359" height="49.84315022379343" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="U1" data-x="-0.30000000000000004" data-y="-3.176258648964843" x="267.39892608219606" y="161.53312466662015" width="23.26782523734198" height="49.85962550858994" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="C1" data-x="1" data-y="-3.176258648964843" x="317.61256793174556" y="166.43709753960135" width="3.3410428484044132" height="39.954887274455615" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="C1" data-x="1" data-y="-3.176258648964843" x="320.57344053893684" y="166.4788903873941" width="3.3421472054163246" height="39.96809406704202" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL1" data-x="-1" data-y="-2.086258648964843" x="251.16411738343007" y="145.54315799331854" width="3.3228766815862514" height="9.304054708441441" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL1" data-x="-1" data-y="-2.086258648964843" x="254.10302594657207" y="145.57804450387135" width="3.323975033905981" height="9.307130094936781" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL2" data-x="-1" data-y="-4.266258648964843" x="251.16411738343007" y="217.98186965189834" width="3.3228766815862514" height="9.304054708441441" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL2" data-x="-1" data-y="-4.266258648964843" x="254.10302594657207" y="218.04070024302212" width="3.323975033905981" height="9.307130094936753" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="U1" data-x="1.8003075187499997" data-y="-3.176258648964843" x="334.246252891921" y="161.49296606493243" width="23.26013677110359" height="49.84315022379343" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="U1" data-x="1.8003075187499997" data-y="-3.176258648964843" x="337.21262364069656" y="161.53312466662015" width="23.26782523734198" height="49.85962550858994" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL3" data-x="2.5003075187499997" data-y="-2.086258648964843" x="367.4750197077833" y="145.54315799331854" width="3.3228766815862514" height="9.304054708441441" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL3" data-x="2.5003075187499997" data-y="-2.086258648964843" x="370.45237397975654" y="145.57804450387135" width="3.323975033905981" height="9.307130094936781" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL4" data-x="2.5003075187499997" data-y="-4.266258648964843" x="367.4750197077833" y="217.98186965189834" width="3.3228766815862514" height="9.304054708441441" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL4" data-x="2.5003075187499997" data-y="-4.266258648964843" x="370.45237397975654" y="218.04070024302212" width="3.323975033905981" height="9.307130094936753" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="U1" data-x="0.30027334999999966" data-y="-6.36376825892578" x="284.4019672827015" y="267.4099796176446" width="23.26013677110359" height="49.84315022379337" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="U1" data-x="0.30027334999999966" data-y="-6.36376825892578" x="287.3518623713872" y="267.4851483050761" width="23.26782523734198" height="49.85962550858994" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="C1" data-x="-0.9997266500000004" data-y="-6.36376825892578" x="251.16411738343007" y="272.3541110923135" width="3.3410428484044417" height="39.95488727445559" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="C1" data-x="-0.9997266500000004" data-y="-6.36376825892578" x="254.10302594657207" y="272.4309140258501" width="3.3421472054163246" height="39.968094067042045" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL1" data-x="1.0002733499999996" data-y="-5.27376825892578" x="317.6307340985638" y="251.46017154603067" width="3.3228766815861945" height="9.304054708441413" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL1" data-x="1.0002733499999996" data-y="-5.27376825892578" x="320.5916127104472" y="251.53006814232734" width="3.323975033905981" height="9.30713009493681" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL2" data-x="1.0002733499999996" data-y="-7.45376825892578" x="317.6307340985638" y="323.89888320461046" width="3.3228766815861945" height="9.304054708441413" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL2" data-x="1.0002733499999996" data-y="-7.45376825892578" x="320.5916127104472" y="323.99272388147807" width="3.323975033905981" height="9.307130094936781" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="U1" data-x="1.8003075187499997" data-y="-6.36376825892578" x="334.246252891921" y="267.4099796176446" width="23.26013677110359" height="49.84315022379337" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="U1" data-x="1.8003075187499997" data-y="-6.36376825892578" x="337.21262364069656" y="267.4851483050761" width="23.26782523734198" height="49.85962550858994" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL3" data-x="2.5003075187499997" data-y="-5.27376825892578" x="367.4750197077833" y="251.46017154603067" width="3.3228766815862514" height="9.304054708441413" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL3" data-x="2.5003075187499997" data-y="-5.27376825892578" x="370.45237397975654" y="251.53006814232734" width="3.323975033905981" height="9.30713009493681" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL4" data-x="2.5003075187499997" data-y="-7.45376825892578" x="367.4750197077833" y="323.89888320461046" width="3.3228766815862514" height="9.304054708441413" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL4" data-x="2.5003075187499997" data-y="-7.45376825892578" x="370.45237397975654" y="323.99272388147807" width="3.323975033905981" height="9.307130094936781" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="U1" data-x="-0.7" data-y="-9.316545313671872" x="251.16411738343007" y="365.5271198290311" width="23.260136771103618" height="49.84315022379343" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="U1" data-x="-0.7" data-y="-9.311533438671873" x="254.10302594657207" y="365.4681269380105" width="23.26782523734198" height="49.85962550858994" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="C1" data-x="0.7246073493080432" data-y="-9.31310201902598" x="308.46160975910027" y="370.3568348688333" width="3.34104284840447" height="39.95488727445564" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="C1" data-x="0.7246073493080432" data-y="-9.30809014402598" x="311.4194575847242" y="370.29943840441115" width="3.3421472054163814" height="39.9680940670421" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL1" data-x="0.7246073493080432" data-y="-8.426545313671872" x="308.4706928425094" y="356.22306512058964" width="3.3228766815862514" height="9.30405470844147" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL1" data-x="0.7246073493080432" data-y="-8.421533438671872" x="311.4285436704794" y="356.1609968430737" width="3.323975033905981" height="9.307130094936838" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL2" data-x="0.7246073493080432" data-y="-10.206545313671873" x="308.4706928425094" y="415.37027005282454" width="3.3228766815862514" height="9.30405470844147" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL2" data-x="0.7246073493080432" data-y="-10.201533438671873" x="311.4285436704794" y="415.32775244660047" width="3.323975033905981" height="9.307130094936838" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="U1" data-x="1.7997499999999995" data-y="-9.516545313671871" x="334.22772723138183" y="372.1728731922035" width="23.26013677110359" height="49.84315022379343" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="U1" data-x="1.7799500000000004" data-y="-9.591533438671872" x="336.53594479992387" y="374.77525703294725" width="23.26782523734198" height="49.85962550858994" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL3" data-x="2.7997499999999995" data-y="-8.826545313671872" x="377.42512409200276" y="369.51457184693453" width="3.3228766815862514" height="9.30405470844147" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL3" data-x="2.7799500000000004" data-y="-9.101533438671872" x="379.74762024070185" y="378.76402707363445" width="3.323975033905981" height="9.307130094936838" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL4" data-x="2.7997499999999995" data-y="-10.206545313671873" x="377.42512409200276" y="415.37027005282454" width="3.3228766815862514" height="9.30405470844147" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL4" data-x="2.7799500000000004" data-y="-10.081533438671872" x="379.74762024070185" y="411.33898240591327" width="3.323975033905981" height="9.307130094936724" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="U1" data-x="0.42488069930804273" data-y="-12.006529898298417" x="288.54251583640115" y="454.9119903298507" width="23.26013677110359" height="49.84315022379343" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="U1" data-x="0.42488069930804273" data-y="-12.000961148298419" x="291.4937795527986" y="454.8640325609467" width="23.26782523734198" height="49.85962550859006" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="C1" data-x="-0.9997266500000004" data-y="-12.003086603652525" x="251.16411738343007" y="459.74170536965295" width="3.3410428484044417" height="39.95488727445564" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="C1" data-x="-0.9997266500000004" data-y="-11.997517853652527" x="254.10302594657207" y="459.69534402734746" width="3.3421472054163246" height="39.96809406704199" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL1" data-x="-0.9997266500000004" data-y="-11.116529898298417" x="251.17320046683918" y="445.60793562140924" width="3.322876681586223" height="9.30405470844147" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL1" data-x="-0.9997266500000004" data-y="-11.110961148298419" x="254.11211203232725" y="445.5569024660099" width="3.3239750339060095" height="9.307130094936838" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL2" data-x="-0.9997266500000004" data-y="-12.896529898298418" x="251.17320046683918" y="504.75514055364414" width="3.322876681586223" height="9.304054708441583" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL2" data-x="-0.9997266500000004" data-y="-12.89096114829842" x="254.11211203232725" y="504.7236580695368" width="3.3239750339060095" height="9.307130094936724" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="U1" data-x="1.5279907867215483" data-y="-12.206529898298417" x="325.19750370328995" y="461.55774369302316" width="23.260136771103646" height="49.84315022379343" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="U1" data-x="1.5279907867215483" data-y="-12.280961148298418" x="328.16088345492216" y="464.17116265588356" width="23.26782523734198" height="49.85962550858994" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL3" data-x="2.5279907867215483" data-y="-11.516529898298417" x="368.39490056391094" y="458.8994423477542" width="3.3228766815861945" height="9.30405470844147" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL3" data-x="2.5279907867215483" data-y="-11.790961148298418" x="371.37255889570014" y="468.15993269657076" width="3.323975033905981" height="9.307130094936724" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL4" data-x="2.5279907867215483" data-y="-12.896529898298418" x="368.39490056391094" y="504.75514055364414" width="3.3228766815861945" height="9.304054708441583" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL4" data-x="2.5279907867215483" data-y="-12.770961148298419" x="371.37255889570014" y="500.73488802884947" width="3.323975033905981" height="9.307130094936838" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="U1" data-x="0.7248806993080428" data-y="-14.592867369506923" x="288.54251583640115" y="540.8527950677651" width="43.197396860620984" height="49.84315022379337" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="U1" data-x="0.7248806993080428" data-y="-14.587298619506925" x="291.4937795527986" y="540.8332443964732" width="43.21167544077798" height="49.85962550858994" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="C1" data-x="-0.9997266500000004" data-y="-14.58942407486103" x="251.16411738343007" y="545.6825101075674" width="3.3410428484044417" height="39.95488727445559" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="C1" data-x="-0.9997266500000004" data-y="-14.583855324861032" x="254.10302594657207" y="545.6645558628738" width="3.3421472054163246" height="39.9680940670421" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL1" data-x="-0.9997266500000004" data-y="-13.702867369506922" x="251.17320046683918" y="531.5487403593236" width="3.322876681586223" height="9.304054708441527" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL1" data-x="-0.9997266500000004" data-y="-13.697298619506924" x="254.11211203232725" y="531.5261143015364" width="3.3239750339060095" height="9.307130094936838" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL2" data-x="-0.9997266500000004" data-y="-15.482867369506923" x="251.17320046683918" y="590.6959452915585" width="3.322876681586223" height="9.304054708441527" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL2" data-x="-0.9997266500000004" data-y="-15.477298619506925" x="254.11211203232725" y="590.6928699050632" width="3.3239750339060095" height="9.307130094936838" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL3" data-x="2.024880699308043" data-y="-13.902867369506923" x="351.6771727865395" y="538.1944937224962" width="3.3228766815862514" height="9.304054708441413" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
+    <rect data-type="rect" data-label="NL3" data-x="2.024880699308043" data-y="-14.097298619506924" x="354.64930519701255" y="544.8220144371604" width="3.323975033906038" height="9.307130094936838" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL4" data-x="2.024880699308043" data-y="-15.282867369506922" x="351.6771727865395" y="584.0501919283861" width="3.3228766815862514" height="9.304054708441413" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.03009440601697665" />
-  </g><text data-type="text" data-label="Original Circuit" data-x="-1.05" data-y="1.2299999999999998" x="251.16411738343007" y="40" fill="black" font-size="4.087138318351061" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Original Circuit</text><text data-type="text" data-label="Partition 0" data-x="0.00013667499999980848" data-y="-1.8562509609960933" x="286.05886408179003" y="142.55231351817008" fill="black" font-size="2.990844475148487" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">Partition 0</text><text data-type="text" data-label="Partition 1" data-x="2.0003075187499997" data-y="-1.8562509609960933" x="352.5220746406453" y="142.55231351817008" fill="black" font-size="2.990844475148487" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">Partition 1</text><text data-type="text" data-label="Canonical Partition 0" data-x="0.00013667499999980848" data-y="-5.04376057095703" x="286.05886408179003" y="248.46932707088217" fill="black" font-size="2.990844475148487" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">Canonical Partition 0</text><text data-type="text" data-label="Canonical Partition 1" data-x="2.0003075187499997" data-y="-5.04376057095703" x="352.5220746406453" y="248.46932707088217" fill="black" font-size="2.990844475148487" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">Canonical Partition 1</text><text data-type="text" data-label="Partition 0 → design007  (d=0.00)" data-x="-1.05" data-y="-8.286545313671873" x="251.16411738343007" y="356.2230651205897" fill="black" font-size="3.4225629820338157" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Partition 0 → design007 (d=0.00)</text><text data-type="text" data-label="Partition 1 → design010  (d=0.00)" data-x="1.4497499999999999" data-y="-8.686545313671871" x="334.22772723138183" y="369.51457184693453" fill="black" font-size="2.7579876457165704" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Partition 1 → design010 (d=0.00)</text><text data-type="text" data-label="Adapted 0" data-x="-0.030299999999999994" data-y="-8.182966563671872" x="285.04749090556487" y="352.78127098976114" fill="black" font-size="3.4417941308284963" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">Adapted 0</text><text data-type="text" data-label="Adapted 1" data-x="2.2714499999999997" data-y="-8.582966563671873" x="361.53180492397587" y="366.0727777161061" fill="black" font-size="3.4417941308284963" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">Adapted 1</text><text data-type="text" data-label="Unreflected Adaptation 0" data-x="-1.05" data-y="-10.976529898298418" x="251.16411738343007" y="445.6079356214093" fill="black" font-size="3.4225629820338157" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Unreflected Adaptation 0</text><text data-type="text" data-label="Unreflected Adaptation 1" data-x="1.1779907867215482" data-y="-11.376529898298417" x="325.19750370328995" y="458.8994423477542" fill="black" font-size="2.7579876457165704" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Unreflected Adaptation 1</text><text data-type="text" data-label="Adapted Unreflected 0" data-x="-0.1375596503459786" data-y="-10.885830128630378" x="281.4833849954674" y="442.5940941248576" fill="black" font-size="3.0138414965516778" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">Adapted Unreflected 0</text><text data-type="text" data-label="Adapted Unreflected 1" data-x="1.8779907867215482" data-y="-11.285830128630378" x="348.45764047439354" y="455.8856008512025" fill="black" font-size="3.0138414965516778" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">Adapted Unreflected 1</text><text data-type="text" data-label="Merged Graph" data-x="-1.05" data-y="-13.562867369506924" x="251.16411738343007" y="531.5487403593237" fill="black" font-size="3.4225629820338157" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Merged Graph</text>
+    <rect data-type="rect" data-label="NL4" data-x="2.024880699308043" data-y="-15.077298619506925" x="354.64930519701255" y="577.3969697694391" width="3.323975033906038" height="9.307130094936838" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.030084461820548084" />
+  </g><text data-type="text" data-label="Original Circuit" data-x="-1.05" data-y="1.2299999999999998" x="254.10302594657207" y="40.00000000000004" fill="black" font-size="4.088489291704376" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Original Circuit</text><text data-type="text" data-label="Partition 0" data-x="0.00013667499999980848" data-y="-1.8562509609960933" x="289.0093068454626" y="142.5862114271941" fill="black" font-size="2.9918330766772616" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">Partition 0</text><text data-type="text" data-label="Partition 1" data-x="2.0003075187499997" data-y="-1.8562509609960933" x="355.4944863271796" y="142.5862114271941" fill="black" font-size="2.9918330766772616" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">Partition 1</text><text data-type="text" data-label="Canonical Partition 0" data-x="0.00013667499999980848" data-y="-5.04376057095703" x="289.0093068454626" y="248.53823506565007" fill="black" font-size="2.9918330766772616" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">Canonical Partition 0</text><text data-type="text" data-label="Canonical Partition 1" data-x="2.0003075187499997" data-y="-5.04376057095703" x="355.4944863271796" y="248.53823506565007" fill="black" font-size="2.9918330766772616" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">Canonical Partition 1</text><text data-type="text" data-label="Partition 0 → design007  (d=0.00)" data-x="-1.05" data-y="-8.281533438671874" x="254.10302594657207" y="356.1609968430737" fill="black" font-size="3.4236942849231777" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Partition 0 → design007 (d=0.00)</text><text data-type="text" data-label="Partition 1 → design010  (d=0.00)" data-x="1.4299500000000003" data-y="-8.841533438671872" x="336.53594479992387" y="374.77525703294725" fill="black" font-size="2.492981275429498" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Partition 1 → design010 (d=0.00)</text><text data-type="text" data-label="Adapted 0" data-x="-0.030299999999999994" data-y="-8.182409688671873" x="287.9975993673115" y="352.8661481404023" fill="black" font-size="3.2948487026713966" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">Adapted 0</text><text data-type="text" data-label="Adapted 1" data-x="2.1724500000000004" data-y="-8.742409688671874" x="361.2164594266759" y="371.48040833027596" fill="black" font-size="3.2948487026713966" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">Adapted 1</text><text data-type="text" data-label="Unreflected Adaptation 0" data-x="-1.05" data-y="-10.97096114829842" x="254.10302594657207" y="445.55690246601" fill="black" font-size="3.4236942849231777" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Unreflected Adaptation 0</text><text data-type="text" data-label="Unreflected Adaptation 1" data-x="1.1779907867215482" data-y="-11.530961148298418" x="328.16088345492216" y="464.17116265588356" fill="black" font-size="2.492981275429498" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Unreflected Adaptation 1</text><text data-type="text" data-label="Adapted Unreflected 0" data-x="-0.1375596503459786" data-y="-10.88026137863038" x="284.43231536835634" y="442.5420647664341" fill="black" font-size="3.0148376995758515" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">Adapted Unreflected 0</text><text data-type="text" data-label="Adapted Unreflected 1" data-x="1.8779907867215482" data-y="-11.44026137863038" x="351.42870869226414" y="461.1563249563077" fill="black" font-size="3.0148376995758515" font-family="sans-serif" text-anchor="middle" dominant-baseline="text-after-edge">Adapted Unreflected 1</text><text data-type="text" data-label="Merged Graph" data-x="-1.05" data-y="-13.557298619506925" x="254.10302594657207" y="531.5261143015364" fill="black" font-size="3.4236942849231777" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Merged Graph</text>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
     <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
@@ -864,12 +864,12 @@ schematic_net_label_3_center" data-x="2.024880699308043" data-y="-15.37286736950
 
       // Calculate real coordinates using inverse transformation
       const matrix = {
-        "a": 33.228766815862286,
+        "a": 33.239750339059974,
         "c": 0,
-        "e": 286.0543225400855,
+        "e": 289.00476380258505,
         "b": 0,
-        "d": -33.228766815862286,
-        "f": 80.8713831835106
+        "d": -33.239750339059974,
+        "f": 80.8848929170438
       };
       // Manually invert and apply the affine transform
       // Since we only use translate and scale, we can directly compute:

--- a/tests/partitionGraphForLayout/__snapshots__/partitionGraphForLayout02.snap.svg
+++ b/tests/partitionGraphForLayout/__snapshots__/partitionGraphForLayout02.snap.svg
@@ -143,22 +143,22 @@ schematic_net_label_1_center" data-x="-0.9997263006919572" data-y="-3.8049999999
   <g>
     <circle data-type="point" data-label="NL3_pin
 vcc
-unnamedsubcircuit12_connectivity_net0" data-x="2.024880699308043" data-y="-2.2249999999999996" cx="486.56176908677526" cy="420.4916420845624" r="3" fill="orange" />
+unnamedsubcircuit12_connectivity_net0" data-x="2.024880699308043" data-y="-2.425" cx="486.56176908677526" cy="442.5172074729597" r="3" fill="orange" />
   </g>
   <g>
     <circle data-type="point" data-label="NL3_center
 netlabel_center
-schematic_net_label_2_center" data-x="2.024880699308043" data-y="-2.045" cx="486.56176908677526" cy="400.6686332350049" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_2_center" data-x="2.024880699308043" data-y="-2.2449999999999997" cx="486.56176908677526" cy="422.69419862340214" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <circle data-type="point" data-label="NL4_pin
 gnd
-unnamedsubcircuit12_connectivity_net1" data-x="2.024880699308043" data-y="-3.425" cx="486.56176908677526" cy="552.6450344149459" r="3" fill="purple" />
+unnamedsubcircuit12_connectivity_net1" data-x="2.024880699308043" data-y="-3.2249999999999996" cx="486.56176908677526" cy="530.6194690265486" r="3" fill="purple" />
   </g>
   <g>
     <circle data-type="point" data-label="NL4_center
 netlabel_center
-schematic_net_label_3_center" data-x="2.024880699308043" data-y="-3.6049999999999995" cx="486.56176908677526" cy="572.4680432645034" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
+schematic_net_label_3_center" data-x="2.024880699308043" data-y="-3.405" cx="486.56176908677526" cy="550.4424778761062" r="3" fill="hsl(338.4, 100%, 50%, 1)" />
   </g>
   <g>
     <polyline data-points="-0.6,0.7 0.6,0.7" data-type="line" data-label="" points="197.48936169001934,98.36774827925272 329.6427540204028,98.36774827925272" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
@@ -230,7 +230,7 @@ schematic_net_label_3_center" data-x="2.024880699308043" data-y="-3.604999999999
     <polyline data-points="0.1248806993080428,-2.125 1.3248806993080429,-2.125" data-type="line" data-label="" points="277.3188978970014,409.4788593903638 409.47229022738486,409.4788593903638" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.1248806993080428,-2.125 2.024880699308043,-2.2249999999999996" data-type="line" data-label="" points="277.3188978970014,409.4788593903638 486.56176908677526,420.4916420845624" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.1248806993080428,-2.125 2.024880699308043,-2.425" data-type="line" data-label="" points="277.3188978970014,409.4788593903638 486.56176908677526,442.5172074729597" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
     <polyline data-points="-1.0000003006919573,-2.2703469999999997 -0.9997263006919572,-2.0249999999999995" data-type="line" data-label="" points="153.438197798673,425.4856086529006 153.4683728232551,398.46607669616515" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
@@ -239,16 +239,16 @@ schematic_net_label_3_center" data-x="2.024880699308043" data-y="-3.604999999999
     <polyline data-points="-1.0000003006919573,-2.2703469999999997 1.3248806993080429,-2.125" data-type="line" data-label="" points="153.438197798673,425.4856086529006 409.47229022738486,409.4788593903638" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-1.0000003006919573,-2.2703469999999997 2.024880699308043,-2.2249999999999996" data-type="line" data-label="" points="153.438197798673,425.4856086529006 486.56176908677526,420.4916420845624" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-1.0000003006919573,-2.2703469999999997 2.024880699308043,-2.425" data-type="line" data-label="" points="153.438197798673,425.4856086529006 486.56176908677526,442.5172074729597" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
     <polyline data-points="-0.9997263006919572,-2.0249999999999995 1.3248806993080429,-2.125" data-type="line" data-label="" points="153.4683728232551,398.46607669616515 409.47229022738486,409.4788593903638" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.9997263006919572,-2.0249999999999995 2.024880699308043,-2.2249999999999996" data-type="line" data-label="" points="153.4683728232551,398.46607669616515 486.56176908677526,420.4916420845624" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.9997263006919572,-2.0249999999999995 2.024880699308043,-2.425" data-type="line" data-label="" points="153.4683728232551,398.46607669616515 486.56176908677526,442.5172074729597" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="1.3248806993080429,-2.125 2.024880699308043,-2.2249999999999996" data-type="line" data-label="" points="409.47229022738486,409.4788593903638 486.56176908677526,420.4916420845624" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="1.3248806993080429,-2.125 2.024880699308043,-2.425" data-type="line" data-label="" points="409.47229022738486,409.4788593903638 486.56176908677526,442.5172074729597" fill="none" stroke="hsl(45, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
     <polyline data-points="0.1248806993080428,-3.5249999999999995 -0.9994533006919573,-3.3727659999999995" data-type="line" data-label="" points="277.3188978970014,563.6578171091444 153.49843772001026,546.8926175024582" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
@@ -260,7 +260,7 @@ schematic_net_label_3_center" data-x="2.024880699308043" data-y="-3.604999999999
     <polyline data-points="0.1248806993080428,-3.5249999999999995 1.3248806993080429,-3.5249999999999995" data-type="line" data-label="" points="277.3188978970014,563.6578171091444 409.47229022738486,563.6578171091444" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="0.1248806993080428,-3.5249999999999995 2.024880699308043,-3.425" data-type="line" data-label="" points="277.3188978970014,563.6578171091444 486.56176908677526,552.6450344149459" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="0.1248806993080428,-3.5249999999999995 2.024880699308043,-3.2249999999999996" data-type="line" data-label="" points="277.3188978970014,563.6578171091444 486.56176908677526,530.6194690265486" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
     <polyline data-points="-0.9994533006919573,-3.3727659999999995 -0.9997263006919572,-3.625" data-type="line" data-label="" points="153.49843772001026,546.8926175024582 153.4683728232551,574.6705998033432" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
@@ -269,16 +269,16 @@ schematic_net_label_3_center" data-x="2.024880699308043" data-y="-3.604999999999
     <polyline data-points="-0.9994533006919573,-3.3727659999999995 1.3248806993080429,-3.5249999999999995" data-type="line" data-label="" points="153.49843772001026,546.8926175024582 409.47229022738486,563.6578171091444" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.9994533006919573,-3.3727659999999995 2.024880699308043,-3.425" data-type="line" data-label="" points="153.49843772001026,546.8926175024582 486.56176908677526,552.6450344149459" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.9994533006919573,-3.3727659999999995 2.024880699308043,-3.2249999999999996" data-type="line" data-label="" points="153.49843772001026,546.8926175024582 486.56176908677526,530.6194690265486" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
     <polyline data-points="-0.9997263006919572,-3.625 1.3248806993080429,-3.5249999999999995" data-type="line" data-label="" points="153.4683728232551,574.6705998033432 409.47229022738486,563.6578171091444" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="-0.9997263006919572,-3.625 2.024880699308043,-3.425" data-type="line" data-label="" points="153.4683728232551,574.6705998033432 486.56176908677526,552.6450344149459" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="-0.9997263006919572,-3.625 2.024880699308043,-3.2249999999999996" data-type="line" data-label="" points="153.4683728232551,574.6705998033432 486.56176908677526,530.6194690265486" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
-    <polyline data-points="1.3248806993080429,-3.5249999999999995 2.024880699308043,-3.425" data-type="line" data-label="" points="409.47229022738486,563.6578171091444 486.56176908677526,552.6450344149459" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
+    <polyline data-points="1.3248806993080429,-3.5249999999999995 2.024880699308043,-3.2249999999999996" data-type="line" data-label="" points="409.47229022738486,563.6578171091444 486.56176908677526,530.6194690265486" fill="none" stroke="hsl(90, 100%, 50%, 0.5)" stroke-width="1" />
   </g>
   <g>
     <rect data-type="rect" data-label="U1" data-x="0" data-y="0" x="191.98297034292" y="92.8613569321534" width="143.16617502458212" height="165.19174041297936" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.009080357142857143" />
@@ -311,10 +311,10 @@ schematic_net_label_3_center" data-x="2.024880699308043" data-y="-3.604999999999
     <rect data-type="rect" data-label="NL2" data-x="-0.9997266500000004" data-y="-3.715" x="147.96194300762005" y="569.1642084562438" width="11.012782694198648" height="30.83579154375616" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.009080357142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL3" data-x="2.024880699308043" data-y="-2.135" x="481.0553777396759" y="395.16224188790557" width="11.012782694198677" height="30.83579154375616" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.009080357142857143" />
+    <rect data-type="rect" data-label="NL3" data-x="2.024880699308043" data-y="-2.3349999999999995" x="481.0553777396759" y="417.1878072763028" width="11.012782694198677" height="30.83579154375616" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.009080357142857143" />
   </g>
   <g>
-    <rect data-type="rect" data-label="NL4" data-x="2.024880699308043" data-y="-3.5149999999999997" x="481.0553777396759" y="547.1386430678465" width="11.012782694198677" height="30.83579154375616" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.009080357142857143" />
+    <rect data-type="rect" data-label="NL4" data-x="2.024880699308043" data-y="-3.315" x="481.0553777396759" y="525.1130776794494" width="11.012782694198677" height="30.83579154375616" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.009080357142857143" />
   </g><text data-type="text" data-label="Original Circuit" data-x="-1.05" data-y="1.2299999999999998" x="147.93183956612552" y="40.00000000000003" fill="black" font-size="13.545722713864304" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Original Circuit</text><text data-type="text" data-label="Laid-out Circuit" data-x="-1.05" data-y="-1.7949999999999997" x="147.93183956612552" y="373.1366764995083" fill="black" font-size="11.343166175024582" font-family="sans-serif" text-anchor="start" dominant-baseline="text-after-edge">Laid-out Circuit</text>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />


### PR DESCRIPTION
## Summary
- support `accessoryCorpus` in layout functions
- keep `layoutSchematicGraphVariants` in sync
- update dev dependency
- test accessory corpus behaviour
- update snapshots

## Testing
- `bun test tests/accessoryCorpus/accessoryCorpusOption.test.ts`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/partitionGraphForLayout`

------
https://chatgpt.com/codex/tasks/task_b_6872ba33bdc0832e8d9606da60d95ff2