### PR TITLE
Implement accessory corpus layout support

### DIFF
--- a/lib/bpc-graph-editing/netAdaptAccessoryGraph.ts
+++ b/lib/bpc-graph-editing/netAdaptAccessoryGraph.ts
@@ -25,7 +25,30 @@ export const netAdaptAccessoryGraph = (params: {
     floatingToFixedNetworkAssignment,
   } = getApproximateAssignments2(floatingGraph, fixedCorpusMatch)
 
-  // TODO
+  const fixedToFloatingNetworkAssignment: Record<string, string> = {}
+  for (const [floatingNet, fixedNet] of Object.entries(
+    floatingToFixedNetworkAssignment,
+  )) {
+    fixedToFloatingNetworkAssignment[fixedNet] = floatingNet
+  }
 
-  throw new Error("Not implemented")
+  const accessoryGraph: FixedBpcGraph = {
+    boxes: [],
+    pins: [],
+  }
+
+  for (const box of fixedAccessoryCorpusMatch.boxes) {
+    accessoryGraph.boxes.push(structuredClone(box))
+  }
+
+  for (const pin of fixedAccessoryCorpusMatch.pins) {
+    const networkId =
+      fixedToFloatingNetworkAssignment[pin.networkId] ?? pin.networkId
+    accessoryGraph.pins.push({
+      ...structuredClone(pin),
+      networkId,
+    })
+  }
+
+  return accessoryGraph
 }

--- a/lib/schematic-layout/layoutSchematicGraph.ts
+++ b/lib/schematic-layout/layoutSchematicGraph.ts
@@ -120,6 +120,9 @@ export const layoutSchematicGraph = (
       )
       .map(({ adaptedAccessoryGraph, reflected, centerBoxId }) => {
         if (!reflected) return adaptedAccessoryGraph as FixedBpcGraph
+        if (!adaptedAccessoryGraph.boxes.find((b) => b.boxId === centerBoxId)) {
+          return adaptedAccessoryGraph as FixedBpcGraph
+        }
         return reflectGraph({
           graph: adaptedAccessoryGraph as BpcGraph,
           axis: "x",

--- a/lib/schematic-layout/layoutSchematicGraphVariants.ts
+++ b/lib/schematic-layout/layoutSchematicGraphVariants.ts
@@ -9,14 +9,17 @@ export const layoutSchematicGraphVariants = (
     singletonKeys,
     centerPinColors,
     floatingBoxIdsWithMutablePinOffsets,
+    accessoryCorpus,
   }: {
     singletonKeys?: PartitionSingletonKey[]
     centerPinColors?: string[]
     floatingBoxIdsWithMutablePinOffsets?: Set<FloatingBoxId>
     corpus: Record<string, FixedBpcGraph>
+    accessoryCorpus?: Record<string, FixedBpcGraph>
   },
 ): {
   fixedGraph: FixedBpcGraph
+  accessoryFixedGraph?: FixedBpcGraph
   selectedVariantName: string
   variantResults: Array<{ variantName: string; distance: number }>
 } => {
@@ -24,17 +27,19 @@ export const layoutSchematicGraphVariants = (
   let bestVariant: {
     variantName: string
     fixedGraph: FixedBpcGraph
+    accessoryFixedGraph?: FixedBpcGraph
     distance: number
   } | null = null
 
   for (const variant of variants) {
-    const { fixedGraph, distance } = layoutSchematicGraph(
+    const { fixedGraph, accessoryFixedGraph, distance } = layoutSchematicGraph(
       variant.floatingGraph,
       {
         corpus,
         singletonKeys,
         centerPinColors,
         floatingBoxIdsWithMutablePinOffsets,
+        accessoryCorpus,
       },
     )
 
@@ -47,6 +52,7 @@ export const layoutSchematicGraphVariants = (
       bestVariant = {
         variantName: variant.variantName,
         fixedGraph,
+        accessoryFixedGraph,
         distance,
       }
     }
@@ -54,6 +60,7 @@ export const layoutSchematicGraphVariants = (
 
   return {
     fixedGraph: bestVariant!.fixedGraph,
+    accessoryFixedGraph: bestVariant!.accessoryFixedGraph,
     selectedVariantName: bestVariant!.variantName,
     variantResults,
   }

--- a/tests/accessoryCorpus/accessoryCorpus01.test.ts
+++ b/tests/accessoryCorpus/accessoryCorpus01.test.ts
@@ -1,0 +1,122 @@
+import { test, expect } from "bun:test"
+import { layoutSchematicGraph } from "lib/index"
+import type { MixedBpcGraph, FixedBpcGraph } from "lib/types"
+
+const floatingGraph: MixedBpcGraph = {
+  boxes: [{ boxId: "U1", kind: "floating", center: { x: 0, y: 0 } }],
+  pins: [
+    {
+      boxId: "U1",
+      pinId: "p1",
+      networkId: "N1",
+      color: "sig",
+      offset: { x: -1, y: 1 },
+    },
+    {
+      boxId: "U1",
+      pinId: "p2",
+      networkId: "N2",
+      color: "sig",
+      offset: { x: 1, y: 1 },
+    },
+    {
+      boxId: "U1",
+      pinId: "p3",
+      networkId: "N2",
+      color: "sig",
+      offset: { x: 1, y: -1 },
+    },
+    {
+      boxId: "U1",
+      pinId: "p4",
+      networkId: "N2",
+      color: "sig",
+      offset: { x: 1, y: 0 },
+    },
+    {
+      boxId: "U1",
+      pinId: "center",
+      networkId: "C",
+      color: "component_center",
+      offset: { x: 0, y: 0 },
+    },
+  ],
+}
+
+const corpusLeft: FixedBpcGraph = {
+  boxes: [{ boxId: "U1", kind: "fixed", center: { x: 0, y: 0 } }],
+  pins: [
+    {
+      boxId: "U1",
+      pinId: "p1",
+      networkId: "N1",
+      color: "sig",
+      offset: { x: -1, y: 1 },
+    },
+    {
+      boxId: "U1",
+      pinId: "center",
+      networkId: "C",
+      color: "component_center",
+      offset: { x: 0, y: 0 },
+    },
+  ],
+}
+
+const corpusRight: FixedBpcGraph = {
+  boxes: [{ boxId: "U1", kind: "fixed", center: { x: 0, y: 0 } }],
+  pins: [
+    {
+      boxId: "U1",
+      pinId: "p2",
+      networkId: "N2",
+      color: "sig",
+      offset: { x: 1, y: 1 },
+    },
+    {
+      boxId: "U1",
+      pinId: "p3",
+      networkId: "N2",
+      color: "sig",
+      offset: { x: 1, y: -1 },
+    },
+    {
+      boxId: "U1",
+      pinId: "p4",
+      networkId: "N2",
+      color: "sig",
+      offset: { x: 1, y: 0 },
+    },
+    {
+      boxId: "U1",
+      pinId: "center",
+      networkId: "C",
+      color: "component_center",
+      offset: { x: 0, y: 0 },
+    },
+  ],
+}
+
+const accessoryLeft: FixedBpcGraph = {
+  boxes: [{ boxId: "NL1", kind: "fixed", center: { x: -2, y: 0 } }],
+  pins: [
+    {
+      boxId: "NL1",
+      pinId: "n",
+      networkId: "N1",
+      color: "netlabel",
+      offset: { x: 0, y: 0 },
+    },
+  ],
+}
+
+test("accessoryCorpus01", () => {
+  const { accessoryFixedGraph } = layoutSchematicGraph(floatingGraph, {
+    corpus: { left: corpusLeft, right: corpusRight },
+    accessoryCorpus: { left: accessoryLeft },
+    centerPinColors: ["component_center"],
+  })
+
+  expect(accessoryFixedGraph?.boxes.length).toBe(1)
+  expect(accessoryFixedGraph?.pins.length).toBe(1)
+})


### PR DESCRIPTION
## Summary
- implement `netAdaptAccessoryGraph`
- allow accessory corpus usage in `layoutSchematicGraphVariants`
- handle missing center box during reflection
- test layout with accessory corpus splitting into two partitions

## Testing
- `bun test tests/accessoryCorpus/accessoryCorpus01.test.ts`
- `bun test tests/partitionGraphForLayout/partitionGraphForLayout02.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_6873f995c0ec832e80a096fe951b47b4