### PR TITLE
Document schematic layout helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ This repository provides utilities for manipulating and comparing BPC graphs.
     - [mergeBoxSideSubgraphs(graphs)](#mergeboxsidesubgraphsgraphs)
     - [convertToFlatBpcGraph(graph)](#converttoflatbpcgraphgraph)
     - [convertFromFlatBpcGraph(flatBpcGraph)](#convertfromflatbpcgraphflatbpcgraph)
+    - [layoutSchematic(graph, options)](#layoutschematicgraph-options)
+    - [layoutSchematicWithInputVariants(variants, options)](#layoutschematicwithinputvariantsvariants-options)
 
 ## Where BPC graphs are used
 
@@ -224,3 +226,32 @@ from a 2 layer hierarchy to a flat list of nodes and edges.
 ### convertFromFlatBpcGraph(flatBpcGraph)
 
 Rebuild a BPC graph from the flat representation
+
+### layoutSchematic(graph, options)
+
+Automatically partition, match and lay out a floating BPC graph using a corpus of
+known subcircuits.
+
+```ts
+import { layoutSchematicGraph } from "bpc-graph"
+
+const { fixedGraph } = layoutSchematicGraph(floatingGraph, { corpus })
+```
+
+![layout schematic example](tests/readme/__snapshots__/layoutSchematicExample.snap.svg)
+
+### layoutSchematicWithInputVariants(variants, options)
+
+Try multiple input variants of a floating graph and pick the one that best
+matches the corpus.
+
+```ts
+import { layoutSchematicGraphVariants } from "bpc-graph"
+
+const { fixedGraph, selectedVariantName } = layoutSchematicGraphVariants(
+  variants,
+  { corpus },
+)
+```
+
+![layout schematic variants example](tests/readme/__snapshots__/layoutSchematicVariantsExample.snap.svg)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.0.0",
     "@react-hook/resize-observer": "^2.0.2",
-    "@tscircuit/schematic-corpus": "^0.0.55",
+    "@tscircuit/schematic-corpus": "^0.0.74",
     "@types/bun": "latest",
     "@types/debug": "^4.1.12",
     "@vitejs/plugin-react": "^4.5.2",

--- a/tests/readme/__snapshots__/layoutSchematicExample.snap.svg
+++ b/tests/readme/__snapshots__/layoutSchematicExample.snap.svg
@@ -1,0 +1,100 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+  <g>
+    <circle data-type="point" data-label="P1
+red
+N1" data-x="0.5" data-y="0" cx="186.6666666666667" cy="320" r="3" fill="red" /><text x="191.6666666666667" y="315" font-family="sans-serif" font-size="12">P1
+      red
+      N1</text>
+  </g>
+  <g>
+    <circle data-type="point" data-label="P2
+blue
+N2" data-x="0" data-y="0" cx="53.33333333333337" cy="320" r="3" fill="blue" /><text x="58.33333333333337" y="315" font-family="sans-serif" font-size="12">P2
+      blue
+      N2</text>
+  </g>
+  <g>
+    <circle data-type="point" data-label="P1
+red
+N1" data-x="1.5" data-y="0" cx="453.33333333333337" cy="320" r="3" fill="red" /><text x="458.33333333333337" y="315" font-family="sans-serif" font-size="12">P1
+      red
+      N1</text>
+  </g>
+  <g>
+    <circle data-type="point" data-label="P2
+blue
+N2" data-x="2" data-y="0" cx="586.6666666666667" cy="320" r="3" fill="blue" /><text x="591.6666666666667" y="315" font-family="sans-serif" font-size="12">P2
+      blue
+      N2</text>
+  </g>
+  <g>
+    <polyline data-points="0.5,0 1.5,0" data-type="line" data-label="" points="186.6666666666667,320 453.33333333333337,320" fill="none" stroke="hsl(0, 100%, 50%, 0.5)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="0,0 2,0" data-type="line" data-label="" points="53.33333333333337,320 586.6666666666667,320" fill="none" stroke="hsl(180, 100%, 50%, 0.5)" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="A" data-x="0.25" data-y="0" x="40.00000000000004" y="306.6666666666667" width="160" height="26.66666666666663" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.00375" /><text x="45.00000000000004" y="306.6666666666667" font-family="sans-serif" dominant-baseline="text-before-edge" font-size="5.599999999999999" fill="black">A</text>
+  </g>
+  <g>
+    <rect data-type="rect" data-label="B" data-x="1.75" data-y="0" x="440.00000000000006" y="306.6666666666667" width="159.99999999999994" height="26.66666666666663" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.00375" /><text x="445.00000000000006" y="306.6666666666667" font-family="sans-serif" dominant-baseline="text-before-edge" font-size="5.599999999999997" fill="black">B</text>
+  </g>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 266.6666666666667,
+        "c": 0,
+        "e": 53.33333333333337,
+        "b": 0,
+        "d": -266.6666666666667,
+        "f": 320
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/readme/__snapshots__/layoutSchematicVariantsExample.snap.svg
+++ b/tests/readme/__snapshots__/layoutSchematicVariantsExample.snap.svg
@@ -1,0 +1,100 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <rect width="100%" height="100%" fill="white" />
+  <g>
+    <circle data-type="point" data-label="P1
+red
+N1" data-x="0.5" data-y="0" cx="186.6666666666667" cy="320" r="3" fill="red" /><text x="191.6666666666667" y="315" font-family="sans-serif" font-size="12">P1
+      red
+      N1</text>
+  </g>
+  <g>
+    <circle data-type="point" data-label="P2
+blue
+N2" data-x="0" data-y="0" cx="53.33333333333337" cy="320" r="3" fill="blue" /><text x="58.33333333333337" y="315" font-family="sans-serif" font-size="12">P2
+      blue
+      N2</text>
+  </g>
+  <g>
+    <circle data-type="point" data-label="P1
+red
+N1" data-x="1.5" data-y="0" cx="453.33333333333337" cy="320" r="3" fill="red" /><text x="458.33333333333337" y="315" font-family="sans-serif" font-size="12">P1
+      red
+      N1</text>
+  </g>
+  <g>
+    <circle data-type="point" data-label="P2
+blue
+N2" data-x="2" data-y="0" cx="586.6666666666667" cy="320" r="3" fill="blue" /><text x="591.6666666666667" y="315" font-family="sans-serif" font-size="12">P2
+      blue
+      N2</text>
+  </g>
+  <g>
+    <polyline data-points="0.5,0 1.5,0" data-type="line" data-label="" points="186.6666666666667,320 453.33333333333337,320" fill="none" stroke="hsl(0, 100%, 50%, 0.5)" stroke-width="1" />
+  </g>
+  <g>
+    <polyline data-points="0,0 2,0" data-type="line" data-label="" points="53.33333333333337,320 586.6666666666667,320" fill="none" stroke="hsl(180, 100%, 50%, 0.5)" stroke-width="1" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="A" data-x="0.25" data-y="0" x="40.00000000000004" y="306.6666666666667" width="160" height="26.66666666666663" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.00375" /><text x="45.00000000000004" y="306.6666666666667" font-family="sans-serif" dominant-baseline="text-before-edge" font-size="5.599999999999999" fill="black">A</text>
+  </g>
+  <g>
+    <rect data-type="rect" data-label="B" data-x="1.75" data-y="0" x="440.00000000000006" y="306.6666666666667" width="159.99999999999994" height="26.66666666666663" fill="rgba(0, 0, 0, 0.2)" stroke="black" stroke-width="0.00375" /><text x="445.00000000000006" y="306.6666666666667" font-family="sans-serif" dominant-baseline="text-before-edge" font-size="5.599999999999997" fill="black">B</text>
+  </g>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 266.6666666666667,
+        "c": 0,
+        "e": 53.33333333333337,
+        "b": 0,
+        "d": -266.6666666666667,
+        "f": 320
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/readme/layoutSchematicExample.test.ts
+++ b/tests/readme/layoutSchematicExample.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "bun:test"
+import { getSvgFromGraphicsObject } from "graphics-debug"
+import { getGraphicsForBpcGraph, layoutSchematicGraph } from "lib/index"
+import type { BpcGraph, FixedBpcGraph } from "lib/types"
+
+const floatingGraph: BpcGraph = {
+  boxes: [
+    { boxId: "A", kind: "floating" },
+    { boxId: "B", kind: "floating" },
+  ],
+  pins: [
+    {
+      boxId: "A",
+      pinId: "P1",
+      offset: { x: 0.5, y: 0 },
+      color: "red",
+      networkId: "N1",
+    },
+    {
+      boxId: "B",
+      pinId: "P1",
+      offset: { x: -0.5, y: 0 },
+      color: "red",
+      networkId: "N1",
+    },
+    {
+      boxId: "A",
+      pinId: "P2",
+      offset: { x: 0, y: 0 },
+      color: "blue",
+      networkId: "N2",
+    },
+    {
+      boxId: "B",
+      pinId: "P2",
+      offset: { x: 0, y: 0 },
+      color: "blue",
+      networkId: "N2",
+    },
+  ],
+}
+
+const corpus: Record<string, FixedBpcGraph> = {
+  Example: {
+    boxes: [
+      { boxId: "A", kind: "fixed", center: { x: 0, y: 0 } },
+      { boxId: "B", kind: "fixed", center: { x: 2, y: 0 } },
+    ],
+    pins: [
+      {
+        boxId: "A",
+        pinId: "P1",
+        offset: { x: 0.5, y: 0 },
+        color: "red",
+        networkId: "N1",
+      },
+      {
+        boxId: "B",
+        pinId: "P1",
+        offset: { x: -0.5, y: 0 },
+        color: "red",
+        networkId: "N1",
+      },
+      {
+        boxId: "A",
+        pinId: "P2",
+        offset: { x: 0, y: 0 },
+        color: "blue",
+        networkId: "N2",
+      },
+      {
+        boxId: "B",
+        pinId: "P2",
+        offset: { x: 0, y: 0 },
+        color: "blue",
+        networkId: "N2",
+      },
+    ],
+  },
+}
+
+test("layoutSchematicGraph example", () => {
+  const { fixedGraph } = layoutSchematicGraph(floatingGraph, { corpus })
+  const svg = getSvgFromGraphicsObject(getGraphicsForBpcGraph(fixedGraph), {
+    backgroundColor: "white",
+    includeTextLabels: true,
+  })
+  expect(svg).toMatchSvgSnapshot(import.meta.path)
+})

--- a/tests/readme/layoutSchematicVariantsExample.test.ts
+++ b/tests/readme/layoutSchematicVariantsExample.test.ts
@@ -1,0 +1,136 @@
+import { expect, test } from "bun:test"
+import { getSvgFromGraphicsObject } from "graphics-debug"
+import { getGraphicsForBpcGraph, layoutSchematicGraphVariants } from "lib/index"
+import type { BpcGraph, FixedBpcGraph } from "lib/types"
+
+const floatingGraph1: BpcGraph = {
+  boxes: [
+    { boxId: "A", kind: "floating" },
+    { boxId: "B", kind: "floating" },
+  ],
+  pins: [
+    {
+      boxId: "A",
+      pinId: "P1",
+      offset: { x: 0.5, y: 0 },
+      color: "red",
+      networkId: "N1",
+    },
+    {
+      boxId: "B",
+      pinId: "P1",
+      offset: { x: -0.5, y: 0 },
+      color: "red",
+      networkId: "N1",
+    },
+    {
+      boxId: "A",
+      pinId: "P2",
+      offset: { x: 0, y: 0 },
+      color: "blue",
+      networkId: "N2",
+    },
+    {
+      boxId: "B",
+      pinId: "P2",
+      offset: { x: 0, y: 0 },
+      color: "blue",
+      networkId: "N2",
+    },
+  ],
+}
+
+const floatingGraph2: BpcGraph = {
+  boxes: [
+    { boxId: "A", kind: "floating" },
+    { boxId: "B", kind: "floating" },
+  ],
+  pins: [
+    {
+      boxId: "A",
+      pinId: "P1",
+      offset: { x: 0.5, y: 0 },
+      color: "red",
+      networkId: "N1",
+    },
+    {
+      boxId: "B",
+      pinId: "P1",
+      offset: { x: -0.5, y: 0 },
+      color: "red",
+      networkId: "N1",
+    },
+    // swapped network for P2 of A to create worse match
+    {
+      boxId: "A",
+      pinId: "P2",
+      offset: { x: 0, y: 0 },
+      color: "blue",
+      networkId: "N1",
+    },
+    {
+      boxId: "B",
+      pinId: "P2",
+      offset: { x: 0, y: 0 },
+      color: "blue",
+      networkId: "N2",
+    },
+  ],
+}
+
+const corpus: Record<string, FixedBpcGraph> = {
+  Example: {
+    boxes: [
+      { boxId: "A", kind: "fixed", center: { x: 0, y: 0 } },
+      { boxId: "B", kind: "fixed", center: { x: 2, y: 0 } },
+    ],
+    pins: [
+      {
+        boxId: "A",
+        pinId: "P1",
+        offset: { x: 0.5, y: 0 },
+        color: "red",
+        networkId: "N1",
+      },
+      {
+        boxId: "B",
+        pinId: "P1",
+        offset: { x: -0.5, y: 0 },
+        color: "red",
+        networkId: "N1",
+      },
+      {
+        boxId: "A",
+        pinId: "P2",
+        offset: { x: 0, y: 0 },
+        color: "blue",
+        networkId: "N2",
+      },
+      {
+        boxId: "B",
+        pinId: "P2",
+        offset: { x: 0, y: 0 },
+        color: "blue",
+        networkId: "N2",
+      },
+    ],
+  },
+}
+
+const variants = [
+  { variantName: "good", floatingGraph: floatingGraph1 },
+  { variantName: "bad", floatingGraph: floatingGraph2 },
+]
+
+test("layoutSchematicGraphVariants example", () => {
+  const { fixedGraph, selectedVariantName } = layoutSchematicGraphVariants(
+    variants,
+    { corpus },
+  )
+  const svg = getSvgFromGraphicsObject(getGraphicsForBpcGraph(fixedGraph), {
+    backgroundColor: "white",
+    includeTextLabels: true,
+  })
+  expect(svg).toMatchSvgSnapshot(import.meta.path)
+  expect(selectedVariantName).toBe("good")
+})


### PR DESCRIPTION
## Summary
- add snapshot tests for layoutSchematicGraph and layoutSchematicGraphVariants
- document layoutSchematicGraph and layoutSchematicGraphVariants in README
- update schematic corpus dependency

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/readme/layoutSchematicExample.test.ts`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/readme/layoutSchematicVariantsExample.test.ts`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68796f80f4cc832eb99502911d5ff6d8